### PR TITLE
Add upper-body-control version of ros2 control interface

### DIFF
--- a/src/engineai_ros2/CMakeLists.txt
+++ b/src/engineai_ros2/CMakeLists.txt
@@ -1,0 +1,141 @@
+cmake_minimum_required(VERSION 3.8)
+project(engineai_ros2)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(interface_protocol REQUIRED)
+find_package(std_srvs REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(ros2_control_cmake REQUIRED)
+set_compiler_options()
+export_windows_symbols()
+
+## GENREATE URDF FILE
+# copy urdf file to share
+find_package(mujoco_simulator REQUIRED)  # get mujoco_simulator_PREFIX here
+get_filename_component(_mujoco_simulator_share_dir "${mujoco_simulator_DIR}" DIRECTORY)  # → ".../share/mujoco_simulator"
+set(ASSET_SRC_ROOT "${_mujoco_simulator_share_dir}/assets/resource/robot/pm_v2/")
+set(ASSET_SRC_MESH_DIR "${ASSET_SRC_ROOT}/meshes")
+set(ASSET_SRC_URDF      "${ASSET_SRC_ROOT}/urdf/serial_pm_v2.urdf")
+
+set(ASSET_DST_ROOT "${CMAKE_CURRENT_BINARY_DIR}/resource/robot/pm_v2")
+set(ASSET_DST_MESH_DIR "${ASSET_DST_ROOT}/meshes")
+set(ASSET_DST_URDF_DIR "${ASSET_DST_ROOT}/urdf")
+set(ASSET_DST_URDF     "${ASSET_DST_URDF_DIR}/serial_pm_v2.urdf")
+
+# copy urdf fileas ROS-friendly
+file(MAKE_DIRECTORY "${ASSET_DST_MESH_DIR}")
+file(MAKE_DIRECTORY "${ASSET_DST_URDF_DIR}")
+file(READ  "${ASSET_SRC_URDF}" _urdf_txt)
+string(REPLACE "package://resource"
+               "package://${PROJECT_NAME}/resource"
+               _urdf_txt "${_urdf_txt}")
+file(WRITE "${ASSET_DST_URDF}" "${_urdf_txt}")
+
+# copy mesh file
+add_custom_command(
+  OUTPUT "${ASSET_DST_MESH_DIR}/.copied"
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${ASSET_DST_MESH_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_directory "${ASSET_SRC_MESH_DIR}" "${ASSET_DST_MESH_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E touch "${ASSET_DST_MESH_DIR}/.copied"
+  DEPENDS "${ASSET_SRC_MESH_DIR}"
+  COMMENT "Copy pm_v2 meshes from mujoco_simulator"
+)
+
+add_custom_target(target_assets ALL
+  DEPENDS "${ASSET_DST_MESH_DIR}/.copied"
+)
+
+# install
+install(DIRECTORY config launch urdf ${CMAKE_CURRENT_BINARY_DIR}/resource
+  DESTINATION "share/${PROJECT_NAME}"
+)
+
+## COMPILE EXECUTABLE
+add_executable(joint_command_mux src/joint_command_mux_node.cpp)
+target_include_directories(joint_command_mux PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
+ament_target_dependencies(joint_command_mux
+  rclcpp
+  std_srvs
+  interface_protocol)
+target_compile_features(joint_command_mux PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+
+install(TARGETS joint_command_mux
+  DESTINATION lib/${PROJECT_NAME})
+
+## COMPILE EXECUTABLE
+add_executable(engineai_cmd_vel_controller src/engineai_cmd_vel_controller_node.cpp)
+target_include_directories(engineai_cmd_vel_controller PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
+ament_target_dependencies(engineai_cmd_vel_controller
+  rclcpp
+  geometry_msgs
+  interface_protocol)
+target_compile_features(engineai_cmd_vel_controller PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+
+install(TARGETS engineai_cmd_vel_controller
+  DESTINATION lib/${PROJECT_NAME})
+
+## COMPILE PLUGINS
+add_library(
+  engineai_hardware_interface
+  SHARED
+  src/engineai_hardware_interface.cpp
+)
+target_compile_features(engineai_hardware_interface PUBLIC cxx_std_17)
+target_include_directories(engineai_hardware_interface PUBLIC
+$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+$<INSTALL_INTERFACE:include/engineai_hardware_interface>
+)
+ament_target_dependencies(engineai_hardware_interface
+  rclcpp
+  rclcpp_lifecycle
+  hardware_interface
+  pluginlib
+  interface_protocol
+)
+
+# Export hardware plugins
+pluginlib_export_plugin_description_file(hardware_interface engineai_hardware_interface.xml)
+
+# Install
+install(
+  DIRECTORY include
+  DESTINATION include
+)
+install(TARGETS engineai_hardware_interface
+  EXPORT export_engineai_hardware_interface
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+## TEST
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+## EXPORTS
+ament_export_targets(export_engineai_hardware_interface HAS_LIBRARY_TARGET)
+ament_export_dependencies(hardware_interface pluginlib rclcpp rclcpp_lifecycle)
+ament_package()

--- a/src/engineai_ros2/CMakeLists.txt
+++ b/src/engineai_ros2/CMakeLists.txt
@@ -1,141 +1,46 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22)
 project(engineai_ros2)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# find dependencies
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(interface_protocol REQUIRED)
-find_package(std_srvs REQUIRED)
-find_package(hardware_interface REQUIRED)
-find_package(pluginlib REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(ros2_control_cmake REQUIRED)
-set_compiler_options()
-export_windows_symbols()
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
-## GENREATE URDF FILE
-# copy urdf file to share
-find_package(mujoco_simulator REQUIRED)  # get mujoco_simulator_PREFIX here
-get_filename_component(_mujoco_simulator_share_dir "${mujoco_simulator_DIR}" DIRECTORY)  # → ".../share/mujoco_simulator"
-set(ASSET_SRC_ROOT "${_mujoco_simulator_share_dir}/assets/resource/robot/pm_v2/")
-set(ASSET_SRC_MESH_DIR "${ASSET_SRC_ROOT}/meshes")
-set(ASSET_SRC_URDF      "${ASSET_SRC_ROOT}/urdf/serial_pm_v2.urdf")
+find_package(mujoco_simulator REQUIRED)
+get_filename_component(_mujoco_share "${mujoco_simulator_DIR}" DIRECTORY)
+set(ASSET_SRC "${_mujoco_share}/assets/resource/robot/pm_v2")
+set(ASSET_DST "${CMAKE_CURRENT_BINARY_DIR}/resource/robot/pm_v2")
 
-set(ASSET_DST_ROOT "${CMAKE_CURRENT_BINARY_DIR}/resource/robot/pm_v2")
-set(ASSET_DST_MESH_DIR "${ASSET_DST_ROOT}/meshes")
-set(ASSET_DST_URDF_DIR "${ASSET_DST_ROOT}/urdf")
-set(ASSET_DST_URDF     "${ASSET_DST_URDF_DIR}/serial_pm_v2.urdf")
+file(MAKE_DIRECTORY "${ASSET_DST}/meshes" "${ASSET_DST}/urdf")
+file(READ  "${ASSET_SRC}/urdf/serial_pm_v2.urdf" _urdf)
+string(REPLACE "package://resource" "package://${PROJECT_NAME}/resource" _urdf "${_urdf}")
+file(WRITE "${ASSET_DST}/urdf/serial_pm_v2.urdf" "${_urdf}")
 
-# copy urdf fileas ROS-friendly
-file(MAKE_DIRECTORY "${ASSET_DST_MESH_DIR}")
-file(MAKE_DIRECTORY "${ASSET_DST_URDF_DIR}")
-file(READ  "${ASSET_SRC_URDF}" _urdf_txt)
-string(REPLACE "package://resource"
-               "package://${PROJECT_NAME}/resource"
-               _urdf_txt "${_urdf_txt}")
-file(WRITE "${ASSET_DST_URDF}" "${_urdf_txt}")
-
-# copy mesh file
 add_custom_command(
-  OUTPUT "${ASSET_DST_MESH_DIR}/.copied"
-  COMMAND ${CMAKE_COMMAND} -E make_directory "${ASSET_DST_MESH_DIR}"
-  COMMAND ${CMAKE_COMMAND} -E copy_directory "${ASSET_SRC_MESH_DIR}" "${ASSET_DST_MESH_DIR}"
-  COMMAND ${CMAKE_COMMAND} -E touch "${ASSET_DST_MESH_DIR}/.copied"
-  DEPENDS "${ASSET_SRC_MESH_DIR}"
+  OUTPUT  "${ASSET_DST}/meshes/.copied"
+  COMMAND ${CMAKE_COMMAND} -E copy_directory "${ASSET_SRC}/meshes" "${ASSET_DST}/meshes"
+  COMMAND ${CMAKE_COMMAND} -E touch "${ASSET_DST}/meshes/.copied"
+  DEPENDS "${ASSET_SRC}/meshes"
   COMMENT "Copy pm_v2 meshes from mujoco_simulator"
 )
+add_custom_target(copy_assets ALL DEPENDS "${ASSET_DST}/meshes/.copied")
 
-add_custom_target(target_assets ALL
-  DEPENDS "${ASSET_DST_MESH_DIR}/.copied"
-)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/resource
+  DESTINATION "share/${PROJECT_NAME}")
 
-# install
-install(DIRECTORY config launch urdf ${CMAKE_CURRENT_BINARY_DIR}/resource
-  DESTINATION "share/${PROJECT_NAME}"
-)
-
-## COMPILE EXECUTABLE
-add_executable(joint_command_mux src/joint_command_mux_node.cpp)
-target_include_directories(joint_command_mux PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-ament_target_dependencies(joint_command_mux
-  rclcpp
-  std_srvs
-  interface_protocol)
-target_compile_features(joint_command_mux PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
-
-install(TARGETS joint_command_mux
-  DESTINATION lib/${PROJECT_NAME})
-
-## COMPILE EXECUTABLE
-add_executable(engineai_cmd_vel_controller src/engineai_cmd_vel_controller_node.cpp)
-target_include_directories(engineai_cmd_vel_controller PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-ament_target_dependencies(engineai_cmd_vel_controller
-  rclcpp
-  geometry_msgs
-  interface_protocol)
-target_compile_features(engineai_cmd_vel_controller PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
-
-install(TARGETS engineai_cmd_vel_controller
-  DESTINATION lib/${PROJECT_NAME})
-
-## COMPILE PLUGINS
-add_library(
-  engineai_hardware_interface
-  SHARED
+ament_auto_add_library(engineai_hardware_interface SHARED
   src/engineai_hardware_interface.cpp
 )
-target_compile_features(engineai_hardware_interface PUBLIC cxx_std_17)
-target_include_directories(engineai_hardware_interface PUBLIC
-$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-$<INSTALL_INTERFACE:include/engineai_hardware_interface>
-)
-ament_target_dependencies(engineai_hardware_interface
-  rclcpp
-  rclcpp_lifecycle
-  hardware_interface
-  pluginlib
-  interface_protocol
-)
-
-# Export hardware plugins
+target_compile_definitions(engineai_hardware_interface PRIVATE "PLUGINLIB_BUILDING_LIBRARY")
 pluginlib_export_plugin_description_file(hardware_interface engineai_hardware_interface.xml)
 
-# Install
-install(
-  DIRECTORY include
-  DESTINATION include
-)
-install(TARGETS engineai_hardware_interface
-  EXPORT export_engineai_hardware_interface
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
+install(FILES engineai_hardware_interface.xml
+  DESTINATION share/${PROJECT_NAME})
+
+ament_auto_add_executable(engineai_cmd_vel_controller
+  src/engineai_cmd_vel_controller_node.cpp
 )
 
-## TEST
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # comment the line when this package is in a git repo and when
-  # a copyright and license is added to all source files
-  set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
-## EXPORTS
-ament_export_targets(export_engineai_hardware_interface HAS_LIBRARY_TARGET)
-ament_export_dependencies(hardware_interface pluginlib rclcpp rclcpp_lifecycle)
-ament_package()
+ament_auto_package(INSTALL_TO_SHARE config launch urdf)

--- a/src/engineai_ros2/LICENSE
+++ b/src/engineai_ros2/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/engineai_ros2/README.md
+++ b/src/engineai_ros2/README.md
@@ -1,0 +1,271 @@
+# engineai_ros2
+
+ROS 2 integration utilities for the EngineAI robot family (PM‑V2 today, designed to be extended to other platforms such as T800).
+
+This package is developed and typically built inside the upstream workspace repository:
+
+- https://github.com/engineai-robotics/engineai_ros2_workspace
+
+---
+
+## What is included
+
+### 1) `engineai_hardware_interface` (ros2_control system plugin)
+
+- Shared library: `libengineai_hardware_interface.so`
+- Plugin XML: `engineai_hardware_interface.xml`
+- Current plugin class (PM‑V2):
+  - `pm_v2_hardware_interface::PM_V2_SystemPositionOnlyHardware`
+
+This naming keeps the **plugin library generic** (`engineai_hardware_interface`) so future robots (e.g., T800) can add additional plugin classes without renaming the package-level interface.
+
+### 2) `joint_command_mux` (node)
+
+Merges two `interface_protocol/msg/JointCommand` topics:
+
+- RL command topic (base + publish clock)
+- ROS command topic (optional upper‑body override)
+
+Publishing rate follows the **RL topic** (the RL callback is the publish clock).  
+Supports smooth transitions when switching the upper‑body source.
+
+### 3) `engineai_cmd_vel_controller` (node)
+
+Converts `geometry_msgs/msg/Twist` (`cmd_vel`) into `interface_protocol/msg/GamepadKeys`
+(EngineAI analog command message used by the downstream interface stack).  
+Publishes a STOP message on shutdown signals.
+
+---
+
+## Workspace setup (recommended)
+
+```bash
+mkdir -p ~/engineai_ws
+cd ~/engineai_ws
+git clone https://github.com/engineai-robotics/engineai_ros2_workspace.git
+cd engineai_ros2_workspace
+
+# Install build dependencies
+
+# Refer to the workspace doc for details:
+# https://github.com/engineai-robotics/engineai_ros2_workspace/tree/community?tab=readme-ov-file#software-dependencies
+# https://github.com/engineai-robotics/engineai_ros2_workspace/tree/community?tab=readme-ov-file#build-instructions
+
+
+# If the workspace provides a .repos file, import/update dependencies like this:
+# vcs import src < engineai_ros2_workspace.repos
+
+# Install dependencies (adjust ROS_DISTRO if needed)
+rosdep update
+rosdep install --from-paths src --ignore-src -r -y
+
+# Build the workspace
+colcon build --packages-up-to engineai_ros2
+
+# Source the setup after building
+source install/setup.bash
+```
+
+---
+## 🚀 Runtime Usage (Full Pipeline)
+
+The EngineAI control stack requires **three components**:
+
+1. MuJoCo simulator  
+2. RL control example  
+3. ROS2 control + joint command mux  
+
+These must be started in the correct order.
+
+---
+
+### 1.  Start MuJoCo Simulator
+
+```bash
+cd ~/engineai_ws/engineai_ros2_workspace
+source install/setup.bash
+
+ros2 launch mujoco_simulator mujoco_simulator.launch.py
+```
+
+Verify that the base hardware topics exist:
+
+```bash
+ros2 topic list | grep joint
+```
+
+You should see something like:
+
+```
+/hardware/joint_command
+/hardware/joint_state
+```
+
+If these topics are missing, the simulator is not running correctly.
+
+### 2. Start RL Example
+```bash
+ros2 launch interface_example rl_basic_example.launch.py joint_command_topic:=/hardware/joint_command_rl
+```
+
+Verify RL command output:
+
+```
+ros2 topic echo -n 1 /hardware/joint_command_rl
+```
+If nothing appears, RL example is not running, Namespace mismatch, or QoS mismatch
+
+### 3. Start engineai_ros2 (ROS2 Control + Mixer)
+
+```bash
+ros2 launch engineai_ros2 ros2_control_pm_v2.launch.py
+```
+After launch, you should see:
+
+```
+/hardware/joint_command_ros
+/hardware/joint_command_rl
+/hardware/joint_command
+```
+The joint_command_mux node merges ROS and RL commands and publishes to /hardware/joint_command
+
+
+### Switching Upper Body Source
+The mixer supports smooth runtime switching between control sources.
+
+Use RL for all joints:
+
+```
+ros2 service call /joint_command_mixer/set_upper_rl std_srvs/srv/SetBool "{data: true}"
+```
+Use ROS for upper body (RL for lower body):
+```
+ros2 service call /joint_command_mixer/set_upper_rl std_srvs/srv/SetBool "{data: false}"
+```
+
+Transitions are smoothed automatically using linear blending.
+
+### Optional: Launch All Components Automatically
+You may create a helper script:
+
+```bash
+#!/bin/bash
+source ~/engineai_ws/engineai_ros2_workspace/install/setup.bash
+
+gnome-terminal -- ros2 launch mujoco_simulator mujoco_simulator.launch.py
+sleep 3
+gnome-terminal -- ros2 launch interface_example rl_basic_example.launch.py joint_command_topic:=/hardware/joint_command_rl
+sleep 3
+gnome-terminal -- ros2 launch engineai_ros2 ros2_control_pm_v2.launch.py
+```
+Save as:
+
+```bash
+start_engineai_pipeline.sh
+```
+Make executable:
+
+```bash
+chmod +x start_engineai_pipeline.sh
+```
+
+Run:
+```bash
+./start_engineai_pipeline.sh
+```
+
+---
+
+## joint_command_mux
+
+### Topics
+
+- Subscribes:
+  - `topic_rl` (default: `/hardware/joint_command_rl`)  
+  - `topic_ros` (default: `/hardware/joint_command_ros`)
+- Publishes:
+  - `topic_out` (default: `/hardware/joint_command`)
+
+### Parameters
+
+- `upper_source` (`string`, default: `ros`)
+  - `ros`: override upper‑body joints from ROS topic
+  - `rl`: do not override (RL provides all joints)
+- `transition_time` (`double`, default: `0.3`)
+  - Seconds to blend when switching `upper_source`.
+- `blend_position_only` (`bool`, default: `true`)
+  - If `true`, only `position[]` is blended/overridden for safety.
+- `joint_names` (`string[]`, default: `[]`)
+  - Joint list in the **same order** as `JointCommand` arrays.
+
+### Service
+
+- `~/set_upper_rl` (`std_srvs/srv/SetBool`)
+  - `data=true`  → `upper_source=rl`
+  - `data=false` → `upper_source=ros`
+
+---
+
+## engineai_cmd_vel_controller
+
+### Topics
+
+- Subscribes:
+  - `cmd_vel` (default: `/cmd_vel`)
+- Publishes:
+  - `interface_protocol/msg/GamepadKeys` (default: `/hardware/gamepad_keys`)
+
+### Parameters
+
+- `cmd_vel_topic` (`string`, default: `/cmd_vel`)
+- `out_topic` (`string`, default: `/hardware/gamepad_keys`)
+- `publish_rate_hz` (`double`, default: `50.0`)  
+  (If set, a timer republishes the last command at this rate.)
+
+---
+
+## Per-joint stiffness/damping configuration (ros2_control)
+
+For PM‑V2 hardware plugin parameters, use the `<ros2_control><hardware><param .../></hardware></ros2_control>` block.
+
+Example (defaults + per-joint overrides):
+
+```xml
+<hardware>
+  <plugin>pm_v2_hardware_interface/PM_V2_SystemPositionOnlyHardware</plugin>
+
+  <param name="default_stiffness">20.0</param>
+  <param name="default_damping">1.0</param>
+
+  <!-- name=value CSV -->
+  <param name="stiffness_by_joint">SHOU_P_L=10.0,ELBO_P_L=8.0</param>
+  <param name="damping_by_joint">SHOU_P_L=0.8,ELBO_P_L=0.7</param>
+</hardware>
+```
+
+---
+
+## URDF / mesh path fix (RViz-friendly)
+
+The original URDF used by the simulator stack contains mesh references like:
+
+- `package://resource/...`
+
+Those paths are not RViz-friendly in this package layout.
+
+During CMake configure/build, we **copy the URDF + meshes from `mujoco_simulator`** into:
+
+- `${PROJECT_NAME}/share/${PROJECT_NAME}/resource/...`
+
+and rewrite the URDF references:
+
+- `package://resource/...` → `package://engineai_ros2/resource/...`
+
+This CMake-time rewrite is intentionally kept because it makes RViz display possible using the installed URDF.
+
+---
+
+
+## License
+
+Apache-2.0

--- a/src/engineai_ros2/config/conf.rviz
+++ b/src/engineai_ros2/config/conf.rviz
@@ -1,0 +1,419 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /RobotModel1
+      Splitter Ratio: 0.5
+    Tree Height: 549
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_common/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Filter (blacklist): ""
+      Filter (whitelist): ""
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        LINK_ANKLE_PITCH_L:
+          Value: true
+        LINK_ANKLE_PITCH_R:
+          Value: true
+        LINK_ANKLE_ROLL_L:
+          Value: true
+        LINK_ANKLE_ROLL_R:
+          Value: true
+        LINK_BASE:
+          Value: true
+        LINK_ELBOW_END_L:
+          Value: true
+        LINK_ELBOW_END_R:
+          Value: true
+        LINK_ELBOW_PITCH_L:
+          Value: true
+        LINK_ELBOW_PITCH_R:
+          Value: true
+        LINK_ELBOW_YAW_L:
+          Value: true
+        LINK_ELBOW_YAW_R:
+          Value: true
+        LINK_FOOT_L:
+          Value: true
+        LINK_FOOT_R:
+          Value: true
+        LINK_HEAD_YAW:
+          Value: true
+        LINK_HIP_PITCH_L:
+          Value: true
+        LINK_HIP_PITCH_R:
+          Value: true
+        LINK_HIP_ROLL_L:
+          Value: true
+        LINK_HIP_ROLL_R:
+          Value: true
+        LINK_HIP_YAW_L:
+          Value: true
+        LINK_HIP_YAW_R:
+          Value: true
+        LINK_KNEE_PITCH_L:
+          Value: true
+        LINK_KNEE_PITCH_R:
+          Value: true
+        LINK_SHOULDER_PITCH_L:
+          Value: true
+        LINK_SHOULDER_PITCH_R:
+          Value: true
+        LINK_SHOULDER_ROLL_L:
+          Value: true
+        LINK_SHOULDER_ROLL_R:
+          Value: true
+        LINK_SHOULDER_YAW_L:
+          Value: true
+        LINK_SHOULDER_YAW_R:
+          Value: true
+        LINK_TORSO_YAW:
+          Value: true
+        world:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: false
+      Tree:
+        world:
+          LINK_BASE:
+            LINK_HIP_PITCH_L:
+              LINK_HIP_ROLL_L:
+                LINK_HIP_YAW_L:
+                  LINK_KNEE_PITCH_L:
+                    LINK_ANKLE_PITCH_L:
+                      LINK_ANKLE_ROLL_L:
+                        LINK_FOOT_L:
+                          {}
+            LINK_HIP_PITCH_R:
+              LINK_HIP_ROLL_R:
+                LINK_HIP_YAW_R:
+                  LINK_KNEE_PITCH_R:
+                    LINK_ANKLE_PITCH_R:
+                      LINK_ANKLE_ROLL_R:
+                        LINK_FOOT_R:
+                          {}
+            LINK_TORSO_YAW:
+              LINK_HEAD_YAW:
+                {}
+              LINK_SHOULDER_PITCH_L:
+                LINK_SHOULDER_ROLL_L:
+                  LINK_SHOULDER_YAW_L:
+                    LINK_ELBOW_PITCH_L:
+                      LINK_ELBOW_YAW_L:
+                        LINK_ELBOW_END_L:
+                          {}
+              LINK_SHOULDER_PITCH_R:
+                LINK_SHOULDER_ROLL_R:
+                  LINK_SHOULDER_YAW_R:
+                    LINK_ELBOW_PITCH_R:
+                      LINK_ELBOW_YAW_R:
+                        LINK_ELBOW_END_R:
+                          {}
+      Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Class: rviz_default_plugins/RobotModel
+      Collision Enabled: false
+      Description File: ""
+      Description Source: Topic
+      Description Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /robot_description
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        LINK_ANKLE_PITCH_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ANKLE_PITCH_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ANKLE_ROLL_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ANKLE_ROLL_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_BASE:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ELBOW_END_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ELBOW_END_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ELBOW_PITCH_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ELBOW_PITCH_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ELBOW_YAW_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ELBOW_YAW_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_FOOT_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_FOOT_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_HEAD_YAW:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_HIP_PITCH_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_HIP_PITCH_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_HIP_ROLL_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_HIP_ROLL_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_HIP_YAW_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_HIP_YAW_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_KNEE_PITCH_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_KNEE_PITCH_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_SHOULDER_PITCH_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_SHOULDER_PITCH_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_SHOULDER_ROLL_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_SHOULDER_ROLL_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_SHOULDER_YAW_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_SHOULDER_YAW_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_TORSO_YAW:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Link Tree Style: Links in Alphabetic Order
+        world:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Mass Properties:
+        Inertia: false
+        Mass: false
+      Name: RobotModel
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 2.1567115783691406
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.2253982424736023
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 5.65358304977417
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 846
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd000000040000000000000156000002b0fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002b0000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002b0fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d000002b0000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b00000027900fffffffb0000000800540069006d006501000000000000045000000000000000000000023f000002b000000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1200
+  X: 60
+  Y: 60

--- a/src/engineai_ros2/config/ekf_imu_only.yaml
+++ b/src/engineai_ros2/config/ekf_imu_only.yaml
@@ -1,0 +1,32 @@
+ekf_node:
+  ros__parameters:
+    frequency: 50.0
+    sensor_timeout: 0.1
+    two_d_mode: false
+
+    # frames
+    map_frame: map
+    odom_frame: odom
+    base_link_frame: LINK_BASE
+    world_frame: odom          # use world if IMU only
+    publish_tf: true
+
+    # IMU
+    imu0: /imu/data_raw
+
+    # [x, y, z, roll, pitch, yaw, vx, vy, vz, vroll, vpitch, vyaw, ax, ay, az]
+    imu0_config: [
+      false, false, false,
+      true,  true,  true,
+      false, false, false,
+      true,  true,  true,
+      false, false, false
+    ]
+
+    imu0_differential: false
+    imu0_relative: false
+
+    # set false if IMU contains gravity value
+    imu0_remove_gravitational_acceleration: true
+
+    # initial_state: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/src/engineai_ros2/config/pm_v2.rviz
+++ b/src/engineai_ros2/config/pm_v2.rviz
@@ -1,0 +1,418 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+      Splitter Ratio: 0.5
+    Tree Height: 549
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_common/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Filter (blacklist): ""
+      Filter (whitelist): ""
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        LINK_ANKLE_PITCH_L:
+          Value: true
+        LINK_ANKLE_PITCH_R:
+          Value: true
+        LINK_ANKLE_ROLL_L:
+          Value: true
+        LINK_ANKLE_ROLL_R:
+          Value: true
+        LINK_BASE:
+          Value: true
+        LINK_ELBOW_END_L:
+          Value: true
+        LINK_ELBOW_END_R:
+          Value: true
+        LINK_ELBOW_PITCH_L:
+          Value: true
+        LINK_ELBOW_PITCH_R:
+          Value: true
+        LINK_ELBOW_YAW_L:
+          Value: true
+        LINK_ELBOW_YAW_R:
+          Value: true
+        LINK_FOOT_L:
+          Value: true
+        LINK_FOOT_R:
+          Value: true
+        LINK_HEAD_YAW:
+          Value: true
+        LINK_HIP_PITCH_L:
+          Value: true
+        LINK_HIP_PITCH_R:
+          Value: true
+        LINK_HIP_ROLL_L:
+          Value: true
+        LINK_HIP_ROLL_R:
+          Value: true
+        LINK_HIP_YAW_L:
+          Value: true
+        LINK_HIP_YAW_R:
+          Value: true
+        LINK_KNEE_PITCH_L:
+          Value: true
+        LINK_KNEE_PITCH_R:
+          Value: true
+        LINK_SHOULDER_PITCH_L:
+          Value: true
+        LINK_SHOULDER_PITCH_R:
+          Value: true
+        LINK_SHOULDER_ROLL_L:
+          Value: true
+        LINK_SHOULDER_ROLL_R:
+          Value: true
+        LINK_SHOULDER_YAW_L:
+          Value: true
+        LINK_SHOULDER_YAW_R:
+          Value: true
+        LINK_TORSO_YAW:
+          Value: true
+        world:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: false
+      Tree:
+        world:
+          LINK_BASE:
+            LINK_HIP_PITCH_L:
+              LINK_HIP_ROLL_L:
+                LINK_HIP_YAW_L:
+                  LINK_KNEE_PITCH_L:
+                    LINK_ANKLE_PITCH_L:
+                      LINK_ANKLE_ROLL_L:
+                        LINK_FOOT_L:
+                          {}
+            LINK_HIP_PITCH_R:
+              LINK_HIP_ROLL_R:
+                LINK_HIP_YAW_R:
+                  LINK_KNEE_PITCH_R:
+                    LINK_ANKLE_PITCH_R:
+                      LINK_ANKLE_ROLL_R:
+                        LINK_FOOT_R:
+                          {}
+            LINK_TORSO_YAW:
+              LINK_HEAD_YAW:
+                {}
+              LINK_SHOULDER_PITCH_L:
+                LINK_SHOULDER_ROLL_L:
+                  LINK_SHOULDER_YAW_L:
+                    LINK_ELBOW_PITCH_L:
+                      LINK_ELBOW_YAW_L:
+                        LINK_ELBOW_END_L:
+                          {}
+              LINK_SHOULDER_PITCH_R:
+                LINK_SHOULDER_ROLL_R:
+                  LINK_SHOULDER_YAW_R:
+                    LINK_ELBOW_PITCH_R:
+                      LINK_ELBOW_YAW_R:
+                        LINK_ELBOW_END_R:
+                          {}
+      Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Class: rviz_default_plugins/RobotModel
+      Collision Enabled: false
+      Description File: ""
+      Description Source: Topic
+      Description Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /robot_description
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        LINK_ANKLE_PITCH_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ANKLE_PITCH_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ANKLE_ROLL_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ANKLE_ROLL_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_BASE:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ELBOW_END_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ELBOW_END_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ELBOW_PITCH_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ELBOW_PITCH_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ELBOW_YAW_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_ELBOW_YAW_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_FOOT_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_FOOT_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_HEAD_YAW:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_HIP_PITCH_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_HIP_PITCH_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_HIP_ROLL_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_HIP_ROLL_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_HIP_YAW_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_HIP_YAW_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_KNEE_PITCH_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_KNEE_PITCH_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_SHOULDER_PITCH_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_SHOULDER_PITCH_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_SHOULDER_ROLL_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_SHOULDER_ROLL_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_SHOULDER_YAW_L:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_SHOULDER_YAW_R:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        LINK_TORSO_YAW:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Link Tree Style: Links in Alphabetic Order
+        world:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Mass Properties:
+        Inertia: false
+        Mass: false
+      Name: RobotModel
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: odom
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 2.1567115783691406
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.4503980576992035
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.7353980541229248
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 846
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd000000040000000000000156000002b0fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002b0000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002b0fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d000002b0000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b00000027900fffffffb0000000800540069006d006501000000000000045000000000000000000000023f000002b000000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1200
+  X: 60
+  Y: 60

--- a/src/engineai_ros2/config/pm_v2_controllers.yaml
+++ b/src/engineai_ros2/config/pm_v2_controllers.yaml
@@ -5,24 +5,16 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    joint_trajectory_controller:
+    # Upper-body controller: waist, both arms, and head.
+    # Leg joints are state-only and controlled by the onboard RL locomotion controller.
+    # Starts INACTIVE; activate with:
+    #   ros2 control set_controller_state upper_body_controller active
+    upper_body_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
-joint_trajectory_controller:
+upper_body_controller:
   ros__parameters:
     joints:
-      - J00_HIP_PITCH_L
-      - J01_HIP_ROLL_L
-      - J02_HIP_YAW_L
-      - J03_KNEE_PITCH_L
-      - J04_ANKLE_PITCH_L
-      - J05_ANKLE_ROLL_L
-      - J06_HIP_PITCH_R
-      - J07_HIP_ROLL_R
-      - J08_HIP_YAW_R
-      - J09_KNEE_PITCH_R
-      - J10_ANKLE_PITCH_R
-      - J11_ANKLE_ROLL_R
       - J12_WAIST_YAW
       - J13_SHOULDER_PITCH_L
       - J14_SHOULDER_ROLL_L
@@ -39,8 +31,3 @@ joint_trajectory_controller:
       - position
     state_interfaces:
       - position
-  
-# forward_position_controller:
-#   ros__parameters:
-#     type: forward_command_controller/ForwardCommandController
-#    interface_name: position

--- a/src/engineai_ros2/config/pm_v2_controllers.yaml
+++ b/src/engineai_ros2/config/pm_v2_controllers.yaml
@@ -1,0 +1,46 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 100  # Hz
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    joint_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+joint_trajectory_controller:
+  ros__parameters:
+    joints:
+      - J00_HIP_PITCH_L
+      - J01_HIP_ROLL_L
+      - J02_HIP_YAW_L
+      - J03_KNEE_PITCH_L
+      - J04_ANKLE_PITCH_L
+      - J05_ANKLE_ROLL_L
+      - J06_HIP_PITCH_R
+      - J07_HIP_ROLL_R
+      - J08_HIP_YAW_R
+      - J09_KNEE_PITCH_R
+      - J10_ANKLE_PITCH_R
+      - J11_ANKLE_ROLL_R
+      - J12_WAIST_YAW
+      - J13_SHOULDER_PITCH_L
+      - J14_SHOULDER_ROLL_L
+      - J15_SHOULDER_YAW_L
+      - J16_ELBOW_PITCH_L
+      - J17_ELBOW_YAW_L
+      - J18_SHOULDER_PITCH_R
+      - J19_SHOULDER_ROLL_R
+      - J20_SHOULDER_YAW_R
+      - J21_ELBOW_PITCH_R
+      - J22_ELBOW_YAW_R
+      - J23_HEAD_YAW
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+  
+# forward_position_controller:
+#   ros__parameters:
+#     type: forward_command_controller/ForwardCommandController
+#    interface_name: position

--- a/src/engineai_ros2/config/pm_v2_controllers.yaml
+++ b/src/engineai_ros2/config/pm_v2_controllers.yaml
@@ -31,3 +31,7 @@ upper_body_controller:
       - position
     state_interfaces:
       - position
+    # When a new rqt goal preempts the current one, start the next trajectory
+    # from the last *commanded* position (not the actual joint position).
+    # This prevents velocity discontinuities at preemption and eliminates jerkiness.
+    open_loop_control: true

--- a/src/engineai_ros2/config/pm_v2_controllers.yaml
+++ b/src/engineai_ros2/config/pm_v2_controllers.yaml
@@ -29,6 +29,7 @@ upper_body_controller:
       - J23_HEAD_YAW
     command_interfaces:
       - position
+      - velocity
     state_interfaces:
       - position
     # When a new rqt goal preempts the current one, start the next trajectory

--- a/src/engineai_ros2/config/pm_v2_joint_command_mux.yaml
+++ b/src/engineai_ros2/config/pm_v2_joint_command_mux.yaml
@@ -1,0 +1,28 @@
+joint_command_mux:
+  ros__parameters:
+    transition_time: 2.0
+    joint_names:
+      - J00_HIP_PITCH_L
+      - J01_HIP_ROLL_L
+      - J02_HIP_YAW_L
+      - J03_KNEE_PITCH_L
+      - J04_ANKLE_PITCH_L
+      - J05_ANKLE_ROLL_L
+      - J06_HIP_PITCH_R
+      - J07_HIP_ROLL_R
+      - J08_HIP_YAW_R
+      - J09_KNEE_PITCH_R
+      - J10_ANKLE_PITCH_R
+      - J11_ANKLE_ROLL_R
+      - J12_WAIST_YAW
+      - J13_SHOULDER_PITCH_L
+      - J14_SHOULDER_ROLL_L
+      - J15_SHOULDER_YAW_L
+      - J16_ELBOW_PITCH_L
+      - J17_ELBOW_YAW_L
+      - J18_SHOULDER_PITCH_R
+      - J19_SHOULDER_ROLL_R
+      - J20_SHOULDER_YAW_R
+      - J21_ELBOW_PITCH_R
+      - J22_ELBOW_YAW_R
+      - J23_HEAD_YAW

--- a/src/engineai_ros2/engineai_hardware_interface.xml
+++ b/src/engineai_ros2/engineai_hardware_interface.xml
@@ -1,0 +1,9 @@
+<library path="engineai_hardware_interface">
+  <class name="engineai_hardware_interface/EngineAI_SystemPositionOnlyHardware"
+         type="engineai_hardware_interface::EngineAI_SystemPositionOnlyHardware"
+         base_class_type="hardware_interface::SystemInterface">
+    <description>
+      EngineAI ros2_control system hardware interface plugins (PM‑V2 today; extendable to other robots).
+    </description>
+  </class>
+</library>

--- a/src/engineai_ros2/include/engineai_ros2/engineai_hardware_interface.hpp
+++ b/src/engineai_ros2/include/engineai_ros2/engineai_hardware_interface.hpp
@@ -1,0 +1,89 @@
+// Copyright 2026 Kei Okada
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ENGINEAI_HARDWARE_INTERFACE_HPP_
+#define ENGINEAI_HARDWARE_INTERFACE_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "hardware_interface/handle.hpp"
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+#include "rclcpp_lifecycle/state.hpp"
+
+#include "interface_protocol/msg/joint_state.hpp"
+#include "interface_protocol/msg/imu_info.hpp"
+#include "interface_protocol/msg/joint_command.hpp"
+#include "sensor_msgs/msg/imu.hpp"
+
+namespace engineai_hardware_interface
+{
+class EngineAI_SystemPositionOnlyHardware : public hardware_interface::SystemInterface
+{
+public:
+  RCLCPP_SHARED_PTR_DEFINITIONS(EngineAI_SystemPositionOnlyHardware)
+
+  hardware_interface::CallbackReturn on_init(
+    const hardware_interface::HardwareComponentInterfaceParams & params) override;
+
+  hardware_interface::CallbackReturn on_configure(
+    const rclcpp_lifecycle::State & previous_state) override;
+
+  hardware_interface::CallbackReturn on_activate(
+    const rclcpp_lifecycle::State & previous_state) override;
+
+  hardware_interface::CallbackReturn on_deactivate(
+    const rclcpp_lifecycle::State & previous_state) override;
+
+  hardware_interface::return_type read(
+    const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+  hardware_interface::return_type write(
+    const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+private:
+  // Parameters for the engineai simulation
+  double hw_start_sec_;
+  double hw_stop_sec_;
+  double hw_slowdown_;
+
+  double default_stiffness_{20.0};
+  double default_damping_{1.0};
+  std::vector<double> stiffness_per_joint_;
+  std::vector<double> damping_per_joint_;
+
+  // Publish & Subscribe
+  rclcpp::Node::SharedPtr node_;
+
+  rclcpp::Subscription<interface_protocol::msg::JointState>::SharedPtr joint_sub_;
+  rclcpp::Subscription<interface_protocol::msg::ImuInfo>::SharedPtr imu_sub_;
+  rclcpp::Publisher<interface_protocol::msg::JointCommand>::SharedPtr joint_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_;
+
+  std::mutex mtx_;
+  std::unordered_map<std::string, double> latest_pos_;
+  std::unordered_map<std::string, double> latest_vel_;
+  std::unordered_map<std::string, double> latest_tor_;  
+  sensor_msgs::msg::Imu latest_imu_;
+  std::vector<std::string> joint_names_;
+};
+
+}  // namespace engineai_hardware_interface
+
+#endif  // ENGINEAI_HARDWARE_INTERFACE_HPP_

--- a/src/engineai_ros2/include/engineai_ros2/engineai_hardware_interface.hpp
+++ b/src/engineai_ros2/include/engineai_ros2/engineai_hardware_interface.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "hardware_interface/handle.hpp"
@@ -29,7 +30,7 @@
 
 #include "interface_protocol/msg/joint_state.hpp"
 #include "interface_protocol/msg/imu_info.hpp"
-#include "interface_protocol/msg/joint_command.hpp"
+#include "interface_protocol/msg/joint_override_command.hpp"
 #include "sensor_msgs/msg/imu.hpp"
 
 namespace engineai_hardware_interface
@@ -57,6 +58,12 @@ public:
   hardware_interface::return_type write(
     const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
+  /// Called by ros2_control when controllers are started/stopped.
+  /// Used to ramp the command weight smoothly (0→1 on activate, 1→0 on deactivate).
+  hardware_interface::return_type perform_command_mode_switch(
+    const std::vector<std::string> & start_interfaces,
+    const std::vector<std::string> & stop_interfaces) override;
+
 private:
   // Parameters for the engineai simulation
   double hw_start_sec_;
@@ -68,20 +75,35 @@ private:
   std::vector<double> stiffness_per_joint_;
   std::vector<double> damping_per_joint_;
 
+  // All joints in order (matches JointCommand array layout)
+  std::vector<std::string> joint_names_;
+
+  // Subset of joint_names_ that have a position command interface (upper-body only)
+  std::vector<std::string> command_joint_names_;
+  std::unordered_set<std::string> command_joint_set_;
+  std::vector<int32_t> command_joint_indices_;   // J-number indices for JointOverrideCommand
+  std::vector<double> command_stiffness_;
+  std::vector<double> command_damping_;
+
+  // Weight ramping: blends commanded position with current state on controller activate/deactivate.
+  // Mirrors the approach in g1_hardware_interface for safe smooth transitions.
+  double weight_{0.0};
+  double ramp_rate_{1.0};   // weight units per second (reaches 1.0 in 1 s)
+  bool controller_active_{false};
+
   // Publish & Subscribe
   rclcpp::Node::SharedPtr node_;
 
   rclcpp::Subscription<interface_protocol::msg::JointState>::SharedPtr joint_sub_;
   rclcpp::Subscription<interface_protocol::msg::ImuInfo>::SharedPtr imu_sub_;
-  rclcpp::Publisher<interface_protocol::msg::JointCommand>::SharedPtr joint_pub_;
+  rclcpp::Publisher<interface_protocol::msg::JointOverrideCommand>::SharedPtr joint_pub_;
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_;
 
   std::mutex mtx_;
   std::unordered_map<std::string, double> latest_pos_;
   std::unordered_map<std::string, double> latest_vel_;
-  std::unordered_map<std::string, double> latest_tor_;  
+  std::unordered_map<std::string, double> latest_tor_;
   sensor_msgs::msg::Imu latest_imu_;
-  std::vector<std::string> joint_names_;
 };
 
 }  // namespace engineai_hardware_interface

--- a/src/engineai_ros2/include/engineai_ros2/engineai_util.hpp
+++ b/src/engineai_ros2/include/engineai_ros2/engineai_util.hpp
@@ -1,0 +1,158 @@
+// Copyright 2026 Kei Okada
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ENGINEAI_UTIL_HPP_
+#define ENGINEAI_UTIL_HPP_
+
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <functional>
+
+std::string compress_joint_name(const std::string & s)
+{
+  // split by '_'
+  std::stringstream ss(s);
+  std::string token;
+  std::vector<std::string> parts;
+  while (std::getline(ss, token, '_')) {
+    parts.push_back(token);
+  }
+
+  if (parts.size() < 2) {
+    return s;  // could not find '_'
+  }
+
+  // Skip prefix(J01) and shrink next toke to 4 letters
+  std::string out;
+  const std::string& first = parts[1];
+  if (!first.empty()) {
+    out = first.substr(0, std::min<size_t>(4, first.size()));
+  } else {
+    out = "";
+  }
+
+  // keep first lteeter for each token
+  for (size_t i = 2; i < parts.size(); ++i) {
+    out.push_back('_');
+    if (!parts[i].empty()) {
+      out.push_back(parts[i][0]);
+    }
+  }
+
+  return out;
+}
+
+// Create a header line with compressed joint names.
+// Example output:
+// cmd:   HIP_R   KNEE_R  ...
+static std::string make_joint_header_line(
+    const std::vector<std::string>& joint_names,
+    int width = 9,
+    const std::string& prefix = "cmd: ")
+{
+  std::ostringstream ss;
+  ss << prefix;
+
+  for (const auto& name : joint_names) {
+    // Print each compressed joint name with fixed column width
+    ss << std::setw(width) << compress_joint_name(name);
+  }
+
+  return ss.str();
+}
+
+
+// Create a value line for a specific joint field (e.g. "/position").
+// Example output:
+//        0.123    -0.532   ...
+static std::string make_joint_value_line(
+    const std::vector<std::string>& joint_names,
+    const std::function<double(const std::string&)>& get_command,
+    const std::string& suffix,     // e.g. "/position"
+    int width = 9,
+    int precision = 3,
+    const std::string& indent = "     ")
+{
+  std::ostringstream ss;
+
+  // Apply fixed floating-point formatting
+  ss << indent << std::fixed << std::setprecision(precision);
+
+  for (const auto& name : joint_names) {
+    // Query value using joint_name + suffix (e.g. "joint/position")
+    ss << std::setw(width) << get_command(name + suffix);
+  }
+
+  return ss.str();
+}
+
+#include <sstream>
+#include <unordered_map>
+
+static std::unordered_map<std::string, double>
+parse_name_value_csv(const std::string& s)
+{
+  std::unordered_map<std::string, double> out;
+  std::stringstream ss(s);
+  std::string item;
+
+  while (std::getline(ss, item, ',')) {
+    // trim spaces (simple)
+    auto trim = [](std::string& x) {
+      while (!x.empty() && std::isspace(x.front())) x.erase(x.begin());
+      while (!x.empty() && std::isspace(x.back()))  x.pop_back();
+    };
+    trim(item);
+    if (item.empty()) continue;
+
+    auto pos = item.find('=');
+    if (pos == std::string::npos) continue;
+
+    std::string name = item.substr(0, pos);
+    std::string val  = item.substr(pos + 1);
+    trim(name);
+    trim(val);
+
+    try {
+      out[name] = std::stod(val);
+    } catch (...) {
+      // ignore invalid
+    }
+  }
+  return out;
+}
+
+[[maybe_unused]] inline double get_double_param(
+  const std::unordered_map<std::string, std::string>& p,
+  const std::string& key,
+  double fallback)
+{
+  auto it = p.find(key);
+  if (it == p.end()) return fallback;
+  try { return std::stod(it->second); } catch (...) { return fallback; }
+}
+
+static std::string get_string_param(
+  const std::unordered_map<std::string, std::string>& p,
+  const std::string& key,
+  const std::string& fallback = "")
+{
+  auto it = p.find(key);
+  return (it == p.end()) ? fallback : it->second;
+}
+
+
+#endif  // ENGINEAI_UTIL_HPP_

--- a/src/engineai_ros2/launch/ros2_control_pm_v2.launch.py
+++ b/src/engineai_ros2/launch/ros2_control_pm_v2.launch.py
@@ -17,7 +17,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.conditions import IfCondition
 from launch_ros.parameter_descriptions import ParameterValue
-from launch.substitutions import Command, LaunchConfiguration, PathSubstitution, PathJoinSubstitution
+from launch.substitutions import Command, PathSubstitution, PathJoinSubstitution, LaunchConfiguration
 
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
@@ -29,7 +29,7 @@ robot_description = ParameterValue(
             FindPackageShare("engineai_ros2"),
             "urdf", "pm_v2.urdf.xacro",
         ]),
-    ]),    
+    ]),
     value_type=str,
 )
 
@@ -39,55 +39,45 @@ def generate_launch_description():
         default_value="true",
         description="Start RViz2 automatically with this launch file.",
     )
-    joint_command_ros_arg = DeclareLaunchArgument(
-        'joint_command_ros', default_value='/hardware/joint_command_ros'
-    )
-    joint_command_rl_arg = DeclareLaunchArgument(
-        'joint_command_rl', default_value='/hardware/joint_command_rl'
-    )
-    # Control node
+
+    # ros2_control node: bridges ros2_control ↔ EngineAI hardware.
+    # Hardware interface publishes JointOverrideCommand to /motion/joint_override_command,
+    # so blending with the onboard RL locomotion controller is handled by EngineAI directly.
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
         parameters=[
+            {"robot_description": robot_description},
             PathJoinSubstitution([
                 FindPackageShare("engineai_ros2"),
-                "config","pm_v2_controllers.yaml",
-            ])
-        ],
-        remappings=[
-            ('/hardware/joint_command', LaunchConfiguration('joint_command_ros')),
+                "config", "pm_v2_controllers.yaml",
+            ]),
         ],
         output="both",
     )
-    # robot_state_publisher with robot_description
+
+    # Publishes joint states for visualization (RViz2, MoveIt2, etc.)
     state_publisher_node = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="both",
-        parameters=[
-            {
-                "robot_description": robot_description
-            }
-        ],
+        parameters=[{"robot_description": robot_description}],
     )
-    mux_node = Node(
-        package='engineai_ros2',
-        executable='joint_command_mux',
-        name='joint_command_mux',
-        output='screen',
+
+    ekf_node = Node(
+        package="robot_localization",
+        executable="ekf_node",
+        name="ekf_node",
+        output="log",
         parameters=[
             PathJoinSubstitution([
-                FindPackageShare('engineai_ros2'),
-                'config', 'pm_v2_joint_command_mux.yaml',
+                FindPackageShare("engineai_ros2"),
+                "config", "ekf_imu_only.yaml"
             ])
         ],
-        remappings=[
-            ('/hardware/joint_command_ros', LaunchConfiguration('joint_command_ros')),
-            ('/hardware/joint_command_rl', LaunchConfiguration('joint_command_rl')),
-            # The output topic can also be remapped if needed:
-        ]
+        arguments=["--ros-args", "--log-level", "robot_localization:=debug"]
     )
+
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
@@ -95,74 +85,49 @@ def generate_launch_description():
         output="log",
         arguments=[
             "-d",
-            PathSubstitution(FindPackageShare("engineai_ros2"))
-            / "config/pm_v2.rviz",
+            PathSubstitution(FindPackageShare("engineai_ros2")) / "config/pm_v2.rviz",
         ],
         condition=IfCondition(LaunchConfiguration("gui")),
     )
-    ekf_node = Node(
-        package="robot_localization",
-        executable="ekf_node",
-        name="ekf_node",
-        output="log",
-        parameters = [
-            PathJoinSubstitution([
-                FindPackageShare("engineai_ros2"),
-                "config",
-                "ekf_imu_only.yaml"
-            ])
-        ],
-        arguments=[
-            "--ros-args",
-            "--log-level",
-            "robot_localization:=debug"
-            ]
-        )
+
+    # Always-active: broadcasts /joint_states for RViz2 / robot_state_publisher.
     broadcaster_node = Node(
         package="controller_manager",
         executable="spawner",
         arguments=["joint_state_broadcaster"],
     )
-    controller_node = Node(
+
+    # Upper-body controller: starts INACTIVE (matching g1_ros pattern).
+    # Activate when upper-body control is needed:
+    #   ros2 control set_controller_state upper_body_controller active
+    upper_body_controller_node = Node(
         package="controller_manager",
         executable="spawner",
         arguments=[
-            "joint_trajectory_controller",
+            "upper_body_controller",
             "--param-file",
             PathSubstitution(FindPackageShare("engineai_ros2"))
-            / "config"
-            / "pm_v2_controllers.yaml",
+            / "config" / "pm_v2_controllers.yaml",
+            "--inactive",
         ],
     )
-    controller_node = Node(
-        package="controller_manager",
-        executable="spawner",
-        arguments=[
-            "joint_trajectory_controller",
-            "--param-file",
-            PathSubstitution(FindPackageShare("engineai_ros2"))
-            / "config"
-            / "pm_v2_controllers.yaml",
-        ],
-    )
+
     cmd_vel_controller_node = Node(
         package='engineai_ros2',
         executable='engineai_cmd_vel_controller',
         name='engineai_cmd_vel_controller',
         output='screen',
     )
+
     return LaunchDescription(
         [
             gui_arg,
-            joint_command_ros_arg,
-            joint_command_rl_arg,
             control_node,
             state_publisher_node,
-            mux_node,
             ekf_node,
             rviz_node,
             broadcaster_node,
-            controller_node,
-            cmd_vel_controller_node
+            upper_body_controller_node,
+            cmd_vel_controller_node,
         ]
     )

--- a/src/engineai_ros2/launch/ros2_control_pm_v2.launch.py
+++ b/src/engineai_ros2/launch/ros2_control_pm_v2.launch.py
@@ -1,0 +1,168 @@
+# Copyright 2025 Kei Okada
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch_ros.parameter_descriptions import ParameterValue
+from launch.substitutions import Command, LaunchConfiguration, PathSubstitution, PathJoinSubstitution
+
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+robot_description = ParameterValue(
+    Command([
+        "xacro ",
+        PathJoinSubstitution([
+            FindPackageShare("engineai_ros2"),
+            "urdf", "pm_v2.urdf.xacro",
+        ]),
+    ]),    
+    value_type=str,
+)
+
+def generate_launch_description():
+    gui_arg = DeclareLaunchArgument(
+        "gui",
+        default_value="true",
+        description="Start RViz2 automatically with this launch file.",
+    )
+    joint_command_ros_arg = DeclareLaunchArgument(
+        'joint_command_ros', default_value='/hardware/joint_command_ros'
+    )
+    joint_command_rl_arg = DeclareLaunchArgument(
+        'joint_command_rl', default_value='/hardware/joint_command_rl'
+    )
+    # Control node
+    control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[
+            PathJoinSubstitution([
+                FindPackageShare("engineai_ros2"),
+                "config","pm_v2_controllers.yaml",
+            ])
+        ],
+        remappings=[
+            ('/hardware/joint_command', LaunchConfiguration('joint_command_ros')),
+        ],
+        output="both",
+    )
+    # robot_state_publisher with robot_description
+    state_publisher_node = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        output="both",
+        parameters=[
+            {
+                "robot_description": robot_description
+            }
+        ],
+    )
+    mux_node = Node(
+        package='engineai_ros2',
+        executable='joint_command_mux',
+        name='joint_command_mux',
+        output='screen',
+        parameters=[
+            PathJoinSubstitution([
+                FindPackageShare('engineai_ros2'),
+                'config', 'pm_v2_joint_command_mux.yaml',
+            ])
+        ],
+        remappings=[
+            ('/hardware/joint_command_ros', LaunchConfiguration('joint_command_ros')),
+            ('/hardware/joint_command_rl', LaunchConfiguration('joint_command_rl')),
+            # The output topic can also be remapped if needed:
+        ]
+    )
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=[
+            "-d",
+            PathSubstitution(FindPackageShare("engineai_ros2"))
+            / "config/pm_v2.rviz",
+        ],
+        condition=IfCondition(LaunchConfiguration("gui")),
+    )
+    ekf_node = Node(
+        package="robot_localization",
+        executable="ekf_node",
+        name="ekf_node",
+        output="log",
+        parameters = [
+            PathJoinSubstitution([
+                FindPackageShare("engineai_ros2"),
+                "config",
+                "ekf_imu_only.yaml"
+            ])
+        ],
+        arguments=[
+            "--ros-args",
+            "--log-level",
+            "robot_localization:=debug"
+            ]
+        )
+    broadcaster_node = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["joint_state_broadcaster"],
+    )
+    controller_node = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[
+            "joint_trajectory_controller",
+            "--param-file",
+            PathSubstitution(FindPackageShare("engineai_ros2"))
+            / "config"
+            / "pm_v2_controllers.yaml",
+        ],
+    )
+    controller_node = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[
+            "joint_trajectory_controller",
+            "--param-file",
+            PathSubstitution(FindPackageShare("engineai_ros2"))
+            / "config"
+            / "pm_v2_controllers.yaml",
+        ],
+    )
+    cmd_vel_controller_node = Node(
+        package='engineai_ros2',
+        executable='engineai_cmd_vel_controller',
+        name='engineai_cmd_vel_controller',
+        output='screen',
+    )
+    return LaunchDescription(
+        [
+            gui_arg,
+            joint_command_ros_arg,
+            joint_command_rl_arg,
+            control_node,
+            state_publisher_node,
+            mux_node,
+            ekf_node,
+            rviz_node,
+            broadcaster_node,
+            controller_node,
+            cmd_vel_controller_node
+        ]
+    )

--- a/src/engineai_ros2/package.xml
+++ b/src/engineai_ros2/package.xml
@@ -7,38 +7,26 @@
   <maintainer email="kei.okada@gmail.com">Kei Okada</maintainer>
   <license>Apache-2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
   <build_depend>mujoco_simulator</build_depend>
-  <build_depend>ros2_control_cmake</build_depend>
 
-  <depend>rclcpp</depend>
   <depend>geometry_msgs</depend>
-  <depend>sensor_msgs</depend>
-  <depend>std_srvs</depend>
-  <depend>interface_protocol</depend>
   <depend>hardware_interface</depend>
+  <depend>interface_protocol</depend>
   <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>sensor_msgs</depend>
 
-  <exec_depend>ros2_control</exec_depend>
-  <exec_depend>ros2_controllers</exec_depend>
   <exec_depend>controller_manager</exec_depend>
-  <exec_depend>forward_command_controller</exec_depend>
-  <exec_depend>interface_example</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
-  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
-  <exec_depend>robot_localization</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>ros2controlcli</exec_depend>
-  <exec_depend>ros2launch</exec_depend>
+  <exec_depend>ros2_control</exec_depend>
   <exec_depend>rqt_joint_trajectory_controller</exec_depend>
-  <exec_depend>rqt_robot_steering</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
-
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/engineai_ros2/package.xml
+++ b/src/engineai_ros2/package.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>engineai_ros2</name>
+  <version>0.1.0</version>
+  <description>ROS 2 integration for EngineAI PM-V2: ros2_control hardware plugin and command utilities.</description>
+  <maintainer email="kei.okada@gmail.com">Kei Okada</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>mujoco_simulator</build_depend>
+  <build_depend>ros2_control_cmake</build_depend>
+
+  <depend>rclcpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>interface_protocol</depend>
+  <depend>hardware_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp_lifecycle</depend>
+
+  <exec_depend>ros2_control</exec_depend>
+  <exec_depend>ros2_controllers</exec_depend>
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>forward_command_controller</exec_depend>
+  <exec_depend>interface_example</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>robot_localization</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>ros2controlcli</exec_depend>
+  <exec_depend>ros2launch</exec_depend>
+  <exec_depend>rqt_joint_trajectory_controller</exec_depend>
+  <exec_depend>rqt_robot_steering</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/engineai_ros2/src/engineai_cmd_vel_controller_node.cpp
+++ b/src/engineai_ros2/src/engineai_cmd_vel_controller_node.cpp
@@ -1,0 +1,176 @@
+// Copyright 2026 Kei Okada
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A small utility node that converts geometry_msgs/Twist commands to
+// interface_protocol/GamepadKeys for the EngineAI hardware interface.
+//
+// Notes:
+// - The node re-publishes at a fixed rate (timer) using the latest cmd_vel.
+// - On SIGINT/SIGTERM/SIGSEGV and on exceptions, it publishes a STOP command.
+
+#include <algorithm>
+#include <csignal>
+#include <exception>
+#include <memory>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "geometry_msgs/msg/twist.hpp"
+#include "interface_protocol/msg/gamepad_keys.hpp"
+
+namespace engineai_ros2
+{
+
+using GamepadKeys = interface_protocol::msg::GamepadKeys;
+
+class EngineAICmdVelControllerNode final : public rclcpp::Node
+{
+public:
+  EngineAICmdVelControllerNode()
+  : rclcpp::Node("engineai_cmd_vel_controller")
+  {
+    // Parameters
+    this->declare_parameter<std::string>("topic_cmd_vel", "cmd_vel");
+    this->declare_parameter<std::string>("topic_out", "hardware/gamepad_keys");
+    this->declare_parameter<double>("publish_rate_hz", 2.0);
+    this->declare_parameter<double>("max_linear", 1.0);
+    this->declare_parameter<double>("max_angular", 0.2);
+
+    topic_cmd_vel_ = this->get_parameter("topic_cmd_vel").as_string();
+    topic_out_ = this->get_parameter("topic_out").as_string();
+    publish_rate_hz_ = this->get_parameter("publish_rate_hz").as_double();
+    max_linear_ = this->get_parameter("max_linear").as_double();
+    max_angular_ = this->get_parameter("max_angular").as_double();
+
+    // Initialize with zero twist.
+    latest_cmd_vel_ = geometry_msgs::msg::Twist();
+
+    // Pub/Sub
+    cmd_vel_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+      topic_cmd_vel_,
+      rclcpp::QoS(10),
+      std::bind(&EngineAICmdVelControllerNode::on_cmd_vel, this, std::placeholders::_1));
+
+    gamepad_pub_ = this->create_publisher<GamepadKeys>(topic_out_, rclcpp::QoS(10));
+
+    // Timer
+    const double safe_hz = (publish_rate_hz_ > 0.0) ? publish_rate_hz_ : 2.0;
+    const auto period = std::chrono::duration<double>(1.0 / safe_hz);
+    timer_ = this->create_wall_timer(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(period),
+      std::bind(&EngineAICmdVelControllerNode::on_timer, this));
+
+    RCLCPP_INFO(
+      get_logger(),
+      "Started engineai_cmd_vel_controller (cmd_vel='%s' -> '%s', rate=%.2f Hz).",
+      topic_cmd_vel_.c_str(),
+      topic_out_.c_str(),
+      safe_hz);
+  }
+
+  void publish_stop()
+  {
+    publish_from_twist(geometry_msgs::msg::Twist());
+  }
+
+private:
+  static double clamp_abs(double v, double limit)
+  {
+    if (limit <= 0.0) {
+      return 0.0;
+    }
+    return std::clamp(v, -limit, limit);
+  }
+
+  void publish_from_twist(const geometry_msgs::msg::Twist & cmd)
+  {
+    GamepadKeys msg;
+
+    // Analog input range is typically [-1, 1].
+    // Here we scale by max_* parameters.
+    const double lx = clamp_abs(cmd.linear.x / max_linear_, 1.0);
+    const double ly = clamp_abs(cmd.linear.y / max_linear_, 1.0);
+    const double ry = clamp_abs(cmd.angular.z / max_angular_, 1.0);
+
+    msg.analog_states[GamepadKeys::LEFT_STICK_X] = lx;
+    msg.analog_states[GamepadKeys::LEFT_STICK_Y] = ly;
+    msg.analog_states[GamepadKeys::RIGHT_STICK_Y] = ry;
+
+    // Throttle logs to keep console readable.
+    RCLCPP_INFO_THROTTLE(
+      get_logger(), *get_clock(), 1000,
+      "publish gamepad_keys: lx=%.2f ly=%.2f ry=%.2f", lx, ly, ry);
+
+    gamepad_pub_->publish(msg);
+  }
+
+  void on_cmd_vel(const geometry_msgs::msg::Twist::SharedPtr msg)
+  {
+    latest_cmd_vel_ = *msg;
+  }
+
+  void on_timer()
+  {
+    publish_from_twist(latest_cmd_vel_);
+  }
+
+private:
+  std::string topic_cmd_vel_;
+  std::string topic_out_;
+  double publish_rate_hz_{2.0};
+  double max_linear_{1.0};
+  double max_angular_{0.2};
+
+  geometry_msgs::msg::Twist latest_cmd_vel_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Publisher<GamepadKeys>::SharedPtr gamepad_pub_;
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
+};
+
+static std::weak_ptr<EngineAICmdVelControllerNode> g_node_weak;
+
+static void signal_handler(int sig)
+{
+  if (auto node = g_node_weak.lock()) {
+    RCLCPP_ERROR(node->get_logger(), "Caught signal %d, publishing STOP then shutdown", sig);
+    node->publish_stop();
+  }
+  rclcpp::shutdown();
+}
+
+}  // namespace engineai_ros2
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<engineai_ros2::EngineAICmdVelControllerNode>();
+  engineai_ros2::g_node_weak = node;
+
+  std::signal(SIGINT, engineai_ros2::signal_handler);
+  std::signal(SIGTERM, engineai_ros2::signal_handler);
+  std::signal(SIGSEGV, engineai_ros2::signal_handler);
+
+  try {
+    rclcpp::spin(node);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(node->get_logger(), "Exception: %s", e.what());
+    node->publish_stop();
+  } catch (...) {
+    RCLCPP_ERROR(node->get_logger(), "Unknown fatal error");
+    node->publish_stop();
+  }
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/engineai_ros2/src/engineai_hardware_interface.cpp
+++ b/src/engineai_ros2/src/engineai_hardware_interface.cpp
@@ -15,6 +15,7 @@
 #include "engineai_ros2/engineai_hardware_interface.hpp"
 #include "engineai_ros2/engineai_util.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <iomanip>
@@ -27,17 +28,11 @@
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include "interface_protocol/msg/parallel_parser_type.hpp"
-
-#include <sstream>
-#include <vector>
-
-#include <sstream>
-#include <string>
-#include <vector>
+#include "interface_protocol/msg/joint_override_command.hpp"
 
 namespace engineai_hardware_interface
 {
+
 hardware_interface::CallbackReturn EngineAI_SystemPositionOnlyHardware::on_init(
   const hardware_interface::HardwareComponentInterfaceParams & params)
 {
@@ -48,28 +43,28 @@ hardware_interface::CallbackReturn EngineAI_SystemPositionOnlyHardware::on_init(
     return hardware_interface::CallbackReturn::ERROR;
   }
 
-  // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
   hw_start_sec_ = stod(info_.hardware_parameters["example_param_hw_start_duration_sec"]);
   hw_stop_sec_ = stod(info_.hardware_parameters["example_param_hw_stop_duration_sec"]);
   hw_slowdown_ = stod(info_.hardware_parameters["example_param_hw_slowdown"]);
   RCLCPP_INFO(get_logger(), "Robot hardware_component update_rate is %dHz", info_.rw_rate);
-  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   for (const hardware_interface::ComponentInfo & joint : info_.joints)
   {
-    // EngineAI_SystemPositionOnly has exactly one state and command interface on each joint
-    if (joint.command_interfaces.size() != 1)
+    // Each joint may have 0 or 1 command interface.
+    // Leg joints (HIP/KNEE/ANKLE) are state-only; upper-body joints have command + state.
+    if (joint.command_interfaces.size() > 1)
     {
       RCLCPP_FATAL(
-        get_logger(), "Joint '%s' has %zu command interfaces found. 1 expected.",
+        get_logger(), "Joint '%s' has %zu command interfaces. 0 or 1 expected.",
         joint.name.c_str(), joint.command_interfaces.size());
       return hardware_interface::CallbackReturn::ERROR;
     }
 
-    if (joint.command_interfaces[0].name != hardware_interface::HW_IF_POSITION)
+    if (joint.command_interfaces.size() == 1 &&
+      joint.command_interfaces[0].name != hardware_interface::HW_IF_POSITION)
     {
       RCLCPP_FATAL(
-        get_logger(), "Joint '%s' have %s command interfaces found. '%s' expected.",
+        get_logger(), "Joint '%s' has '%s' command interface. '%s' expected.",
         joint.name.c_str(), joint.command_interfaces[0].name.c_str(),
         hardware_interface::HW_IF_POSITION);
       return hardware_interface::CallbackReturn::ERROR;
@@ -78,187 +73,208 @@ hardware_interface::CallbackReturn EngineAI_SystemPositionOnlyHardware::on_init(
     if (joint.state_interfaces.size() != 1)
     {
       RCLCPP_FATAL(
-        get_logger(), "Joint '%s' has %zu state interface. 1 expected.", joint.name.c_str(),
-        joint.state_interfaces.size());
+        get_logger(), "Joint '%s' has %zu state interfaces. 1 expected.",
+        joint.name.c_str(), joint.state_interfaces.size());
       return hardware_interface::CallbackReturn::ERROR;
     }
 
     if (joint.state_interfaces[0].name != hardware_interface::HW_IF_POSITION)
     {
       RCLCPP_FATAL(
-        get_logger(), "Joint '%s' have %s state interface. '%s' expected.", joint.name.c_str(),
-        joint.state_interfaces[0].name.c_str(), hardware_interface::HW_IF_POSITION);
+        get_logger(), "Joint '%s' has '%s' state interface. '%s' expected.",
+        joint.name.c_str(), joint.state_interfaces[0].name.c_str(),
+        hardware_interface::HW_IF_POSITION);
       return hardware_interface::CallbackReturn::ERROR;
     }
   }
 
-  // create node
-  node_ = std::make_shared<rclcpp::Node>("engineai_hardware_interface");
-
-  // initialize joint_names
+  // Build joint name lists
   joint_names_.clear();
   joint_names_.reserve(info_.joints.size());
-  for (const auto &j : info_.joints) {
+  command_joint_names_.clear();
+
+  for (const auto & j : info_.joints) {
     joint_names_.push_back(j.name);
+    if (!j.command_interfaces.empty()) {
+      command_joint_names_.push_back(j.name);
+    }
   }
 
-  //
+  command_joint_set_.insert(command_joint_names_.begin(), command_joint_names_.end());
+
+  // Build joint indices for JointOverrideCommand (extract J{N} number from name)
+  command_joint_indices_.clear();
+  for (const auto & name : command_joint_names_) {
+    // Name format: J{index}_{rest}, e.g. J12_WAIST_YAW → 12
+    const int idx = std::stoi(name.substr(1, name.find('_') - 1));
+    command_joint_indices_.push_back(static_cast<int32_t>(idx));
+  }
+
+  RCLCPP_INFO(
+    get_logger(), "Total joints: %zu, upper-body (command) joints: %zu",
+    joint_names_.size(), command_joint_names_.size());
+
   const size_t n = joint_names_.size();
 
-  // Initialize per-joint vectors with defaults
+  // Initialize per-joint stiffness/damping with defaults
   stiffness_per_joint_.assign(n, default_stiffness_);
   damping_per_joint_.assign(n, default_damping_);
 
-  // Parse overrides
   const auto stiff_map = parse_name_value_csv(
     get_string_param(info_.hardware_parameters, "stiffness_by_joint", ""));
   const auto damp_map  = parse_name_value_csv(
     get_string_param(info_.hardware_parameters, "damping_by_joint", ""));
 
-  // Apply overrides by joint name
   for (size_t i = 0; i < n; ++i) {
-    const auto& name = joint_names_[i];
-
+    const auto & name = joint_names_[i];
     auto itS = stiff_map.find(name);
     if (itS != stiff_map.end()) stiffness_per_joint_[i] = itS->second;
-
     auto itD = damp_map.find(name);
     if (itD != damp_map.end()) damping_per_joint_[i] = itD->second;
   }
 
-  RCLCPP_INFO(rclcpp::get_logger("EngineAI_SystemPositionOnlyHardware"),
-              "Loaded per-joint stiffness/damping (n=%zu). Defaults: k=%.2f d=%.2f",
-              n, default_stiffness_, default_damping_);
+  RCLCPP_INFO(get_logger(),
+    "Loaded per-joint stiffness/damping (n=%zu). Defaults: k=%.2f d=%.2f",
+    n, default_stiffness_, default_damping_);
 
-  // publisher
+  // Build stiffness/damping subsets for command joints only
+  command_stiffness_.clear();
+  command_damping_.clear();
+  for (size_t i = 0; i < n; ++i) {
+    if (command_joint_set_.count(joint_names_[i])) {
+      command_stiffness_.push_back(stiffness_per_joint_[i]);
+      command_damping_.push_back(damping_per_joint_[i]);
+    }
+  }
+
+  // Publishers
+  node_ = std::make_shared<rclcpp::Node>("engineai_hardware_interface");
   imu_pub_ = node_->create_publisher<sensor_msgs::msg::Imu>("imu/data_raw", rclcpp::QoS(10));
-  
-  joint_pub_ = node_->create_publisher<interface_protocol::msg::JointCommand>
-    ("/hardware/joint_command", rclcpp::QoS(10));
+  joint_pub_ = node_->create_publisher<interface_protocol::msg::JointOverrideCommand>(
+    "/motion/joint_override_command", rclcpp::QoS(10));
 
-  // subscriber
+  // Subscribers — use SensorDataQoS (BEST_EFFORT) to match the EngineAI hardware publisher
   joint_sub_ = node_->create_subscription<interface_protocol::msg::JointState>(
-    "/hardware/joint_state", 10,
+    "/hardware/joint_state", rclcpp::SensorDataQoS(),
     [this](interface_protocol::msg::JointState::SharedPtr msg)
     {
       std::lock_guard<std::mutex> lk(mtx_);
       const auto noj = std::min(joint_names_.size(), msg->position.size());
-      for(size_t i = 0; i < noj; ++i) {
-	latest_pos_[joint_names_[i]] = msg->position[i];
-	latest_vel_[joint_names_[i]] = msg->velocity[i];
-	latest_tor_[joint_names_[i]] = msg->torque[i];						      
+      for (size_t i = 0; i < noj; ++i) {
+        latest_pos_[joint_names_[i]] = msg->position[i];
+        latest_vel_[joint_names_[i]] = msg->velocity[i];
+        latest_tor_[joint_names_[i]] = msg->torque[i];
       }
     });
 
   imu_sub_ = node_->create_subscription<interface_protocol::msg::ImuInfo>(
-    "/hardware/imu_info", 10,
+    "/hardware/imu_info", rclcpp::SensorDataQoS(),
     [this](interface_protocol::msg::ImuInfo::SharedPtr msg)
     {
       std::lock_guard<std::mutex> lk(mtx_);
       latest_imu_.header.stamp = node_->now();
       latest_imu_.header.frame_id = "LINK_BASE";
-      // orientation
       latest_imu_.orientation.x = msg->quaternion.x;
       latest_imu_.orientation.y = msg->quaternion.y;
       latest_imu_.orientation.z = msg->quaternion.z;
       latest_imu_.orientation.w = msg->quaternion.w;
-      // linear
       latest_imu_.linear_acceleration.x = msg->linear_acceleration.x;
       latest_imu_.linear_acceleration.y = msg->linear_acceleration.y;
       latest_imu_.linear_acceleration.z = msg->linear_acceleration.z;
-      // angular
       latest_imu_.angular_velocity.x = msg->angular_velocity.x;
       latest_imu_.angular_velocity.y = msg->angular_velocity.y;
       latest_imu_.angular_velocity.z = msg->angular_velocity.z;
-      // orientation covariance [rad^2]
       latest_imu_.orientation_covariance[0] = 1e-3;
       latest_imu_.orientation_covariance[4] = 1e-3;
       latest_imu_.orientation_covariance[8] = 1e-3;
-      // angular velocity covariance [(rad/s)^2]
       latest_imu_.angular_velocity_covariance[0] = 1e-3;
       latest_imu_.angular_velocity_covariance[4] = 1e-3;
       latest_imu_.angular_velocity_covariance[8] = 1e-3;
-      // linear acceleration covariance [(m/s^2)^2]
       latest_imu_.linear_acceleration_covariance[0] = 1e-2;
       latest_imu_.linear_acceleration_covariance[4] = 1e-2;
       latest_imu_.linear_acceleration_covariance[8] = 1e-2;
-
-      RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 500, "publish latest imu: %7.3f %7.3f %7.3f", latest_imu_.linear_acceleration.x, latest_imu_.linear_acceleration.y, latest_imu_.linear_acceleration.z);
-      // publish
+      RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 500,
+        "publish latest imu: %7.3f %7.3f %7.3f",
+        latest_imu_.linear_acceleration.x,
+        latest_imu_.linear_acceleration.y,
+        latest_imu_.linear_acceleration.z);
       imu_pub_->publish(latest_imu_);
     });
 
-  RCLCPP_INFO(node_->get_logger(), "EngineAI topic-bridge hardware initialized");  
+  RCLCPP_INFO(node_->get_logger(), "EngineAI topic-bridge hardware initialized");
   return hardware_interface::CallbackReturn::SUCCESS;
 }
 
 hardware_interface::CallbackReturn EngineAI_SystemPositionOnlyHardware::on_configure(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(get_logger(), "Configuring ...please wait...");
-
-  for (int i = 0; i < hw_start_sec_; i++)
-  {
+  for (int i = 0; i < hw_start_sec_; i++) {
     rclcpp::sleep_for(std::chrono::seconds(1));
     RCLCPP_INFO(get_logger(), "%.1f seconds left...", hw_start_sec_ - i);
   }
-  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
-  // reset values always when configuring hardware
-  for (const auto & [name, descr] : joint_state_interfaces_)
-  {
+  for (const auto & [name, descr] : joint_state_interfaces_) {
     set_state(name, 0.0);
   }
-  for (const auto & [name, descr] : joint_command_interfaces_)
-  {
+  for (const auto & [name, descr] : joint_command_interfaces_) {
     set_command(name, 0.0);
   }
   RCLCPP_INFO(get_logger(), "Successfully configured!");
-
   return hardware_interface::CallbackReturn::SUCCESS;
 }
 
 hardware_interface::CallbackReturn EngineAI_SystemPositionOnlyHardware::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(get_logger(), "Activating ...please wait...");
-
-  for (int i = 0; i < hw_start_sec_; i++)
-  {
+  for (int i = 0; i < hw_start_sec_; i++) {
     rclcpp::sleep_for(std::chrono::seconds(1));
     RCLCPP_INFO(get_logger(), "%.1f seconds left...", hw_start_sec_ - i);
   }
-  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
-  // command and state should be equal when starting
-  for (const auto & [name, descr] : joint_state_interfaces_)
-  {
+  // Initialize command interfaces to current state to avoid jumps
+  for (const auto & [name, descr] : joint_command_interfaces_) {
     set_command(name, get_state(name));
   }
 
   RCLCPP_INFO(get_logger(), "Successfully activated!");
-
   return hardware_interface::CallbackReturn::SUCCESS;
 }
 
 hardware_interface::CallbackReturn EngineAI_SystemPositionOnlyHardware::on_deactivate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(get_logger(), "Deactivating ...please wait...");
-
-  for (int i = 0; i < hw_stop_sec_; i++)
-  {
+  for (int i = 0; i < hw_stop_sec_; i++) {
     rclcpp::sleep_for(std::chrono::seconds(1));
     RCLCPP_INFO(get_logger(), "%.1f seconds left...", hw_stop_sec_ - i);
   }
-
   RCLCPP_INFO(get_logger(), "Successfully deactivated!");
-  // END: This part here is for exemplary purposes - Please do not copy to your production code
-
   return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::return_type EngineAI_SystemPositionOnlyHardware::perform_command_mode_switch(
+  const std::vector<std::string> & start_interfaces,
+  const std::vector<std::string> & stop_interfaces)
+{
+  // Check whether any position command interface is being started or stopped.
+  auto has_position = [](const std::vector<std::string> & ifaces) {
+    return std::any_of(ifaces.begin(), ifaces.end(), [](const std::string & s) {
+      return s.find(hardware_interface::HW_IF_POSITION) != std::string::npos;
+    });
+  };
+
+  if (has_position(start_interfaces)) {
+    controller_active_ = true;
+    // Keep current weight_ so the ramp continues smoothly if partially activated.
+    RCLCPP_INFO(get_logger(), "Upper-body controller activated; ramping weight %.2f → 1.0", weight_);
+  } else if (has_position(stop_interfaces)) {
+    controller_active_ = false;
+    RCLCPP_INFO(get_logger(), "Upper-body controller deactivated; ramping weight %.2f → 0.0", weight_);
+  }
+
+  return hardware_interface::return_type::OK;
 }
 
 hardware_interface::return_type EngineAI_SystemPositionOnlyHardware::read(
@@ -273,48 +289,51 @@ hardware_interface::return_type EngineAI_SystemPositionOnlyHardware::read(
       set_state(joint + "/position", it->second);
     }
   }
-  
   return hardware_interface::return_type::OK;
 }
 
 hardware_interface::return_type EngineAI_SystemPositionOnlyHardware::write(
-  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+  const rclcpp::Time & /*time*/, const rclcpp::Duration & period)
 {
-  // Build header line
-  const auto header = make_joint_header_line(joint_names_);
-  // Build position line
-  const auto pos_line = make_joint_value_line(joint_names_,
-					      [this](const std::string& key) {
-						return get_command(key);
-					      },
-					      "/position");
-  // Print both lines with throttling
-  RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 500, "%s\n%s",
-		       header.c_str(), pos_line.c_str());
-
-  // publish joint_command_ros
-  interface_protocol::msg::JointCommand cmd;
-    
-  // header
-  cmd.header.stamp = get_clock()->now();
-  cmd.header.frame_id = "";  // 必要なら robot 名など
-
-  const size_t n = joint_command_interfaces_.size();
-
-  cmd.position.reserve(n);
-  cmd.velocity.assign(n, 0.0);
-  cmd.feed_forward_torque.assign(n, 0.0);
-  cmd.torque.assign(n, 0.0);
-  cmd.stiffness = stiffness_per_joint_;
-  cmd.damping = damping_per_joint_;
-  for (const auto & name : joint_names_)
-  {
-    cmd.position.push_back(get_command(name + "/position"));  // position command
+  // Update weight ramp (0 → 1 when controller activates, 1 → 0 when deactivates).
+  const double dt = period.seconds();
+  if (controller_active_) {
+    weight_ = std::min(1.0, weight_ + ramp_rate_ * dt);
+  } else {
+    weight_ = std::max(0.0, weight_ - ramp_rate_ * dt);
   }
-  cmd.parallel_parser_type = interface_protocol::msg::ParallelParserType::RL_PARSER;
 
-  joint_pub_->publish(cmd);;
-  
+  // Log command joint positions periodically
+  const auto header = make_joint_header_line(command_joint_names_);
+  const auto pos_line = make_joint_value_line(command_joint_names_,
+    [this](const std::string & key) { return get_command(key); },
+    "/position");
+  RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 500, "weight=%.3f\n%s\n%s",
+    weight_, header.c_str(), pos_line.c_str());
+
+  // Build JointOverrideCommand for upper-body joints only.
+  // weight is sent to the EngineAI onboard controller which handles blending
+  // with the RL locomotion controller internally.
+  interface_protocol::msg::JointOverrideCommand cmd;
+  cmd.header.stamp = get_clock()->now();
+  cmd.header.frame_id = "";
+  cmd.weight = weight_;
+  cmd.joint_indices = command_joint_indices_;
+
+  const size_t nc = command_joint_names_.size();
+  cmd.position.reserve(nc);
+  cmd.velocity.assign(nc, 0.0);
+  cmd.feed_forward_torque.assign(nc, 0.0);
+  cmd.torque.assign(nc, 0.0);
+  cmd.stiffness = command_stiffness_;
+  cmd.damping = command_damping_;
+
+  for (const auto & name : command_joint_names_) {
+    cmd.position.push_back(get_command(name + "/position"));
+  }
+
+  joint_pub_->publish(cmd);
+
   return hardware_interface::return_type::OK;
 }
 

--- a/src/engineai_ros2/src/engineai_hardware_interface.cpp
+++ b/src/engineai_ros2/src/engineai_hardware_interface.cpp
@@ -50,24 +50,26 @@ hardware_interface::CallbackReturn EngineAI_SystemPositionOnlyHardware::on_init(
 
   for (const hardware_interface::ComponentInfo & joint : info_.joints)
   {
-    // Each joint may have 0 or 1 command interface.
-    // Leg joints (HIP/KNEE/ANKLE) are state-only; upper-body joints have command + state.
-    if (joint.command_interfaces.size() > 1)
+    // Each joint may have 0, 1, or 2 command interfaces.
+    // Leg joints (HIP/KNEE/ANKLE) are state-only; upper-body joints have position + velocity.
+    if (joint.command_interfaces.size() > 2)
     {
       RCLCPP_FATAL(
-        get_logger(), "Joint '%s' has %zu command interfaces. 0 or 1 expected.",
+        get_logger(), "Joint '%s' has %zu command interfaces. 0, 1, or 2 expected.",
         joint.name.c_str(), joint.command_interfaces.size());
       return hardware_interface::CallbackReturn::ERROR;
     }
 
-    if (joint.command_interfaces.size() == 1 &&
-      joint.command_interfaces[0].name != hardware_interface::HW_IF_POSITION)
-    {
-      RCLCPP_FATAL(
-        get_logger(), "Joint '%s' has '%s' command interface. '%s' expected.",
-        joint.name.c_str(), joint.command_interfaces[0].name.c_str(),
-        hardware_interface::HW_IF_POSITION);
-      return hardware_interface::CallbackReturn::ERROR;
+    for (const auto & ci : joint.command_interfaces) {
+      if (ci.name != hardware_interface::HW_IF_POSITION &&
+          ci.name != hardware_interface::HW_IF_VELOCITY) {
+        RCLCPP_FATAL(
+          get_logger(), "Joint '%s' has unexpected command interface '%s'. "
+          "'%s' or '%s' expected.",
+          joint.name.c_str(), ci.name.c_str(),
+          hardware_interface::HW_IF_POSITION, hardware_interface::HW_IF_VELOCITY);
+        return hardware_interface::CallbackReturn::ERROR;
+      }
     }
 
     if (joint.state_interfaces.size() != 1)
@@ -233,9 +235,14 @@ hardware_interface::CallbackReturn EngineAI_SystemPositionOnlyHardware::on_activ
     RCLCPP_INFO(get_logger(), "%.1f seconds left...", hw_start_sec_ - i);
   }
 
-  // Initialize command interfaces to current state to avoid jumps
+  // Initialize position command interfaces to current state to avoid jumps.
+  // Velocity command interfaces have no matching state interface; start at 0.
   for (const auto & [name, descr] : joint_command_interfaces_) {
-    set_command(name, get_state(name));
+    if (name.find(hardware_interface::HW_IF_VELOCITY) != std::string::npos) {
+      set_command(name, 0.0);
+    } else {
+      set_command(name, get_state(name));
+    }
   }
 
   RCLCPP_INFO(get_logger(), "Successfully activated!");
@@ -322,7 +329,7 @@ hardware_interface::return_type EngineAI_SystemPositionOnlyHardware::write(
 
   const size_t nc = command_joint_names_.size();
   cmd.position.reserve(nc);
-  cmd.velocity.assign(nc, 0.0);
+  cmd.velocity.reserve(nc);
   cmd.feed_forward_torque.assign(nc, 0.0);
   cmd.torque.assign(nc, 0.0);
   cmd.stiffness = command_stiffness_;
@@ -330,6 +337,9 @@ hardware_interface::return_type EngineAI_SystemPositionOnlyHardware::write(
 
   for (const auto & name : command_joint_names_) {
     cmd.position.push_back(get_command(name + "/position"));
+    // Feed forward JTC-interpolated velocity so the onboard PD can track smoothly.
+    // τ = k*(q_cmd - q) + d*(dq_cmd - dq)  →  d-term ≈ 0 during motion → no "gah"
+    cmd.velocity.push_back(get_command(name + "/velocity"));
   }
 
   joint_pub_->publish(cmd);

--- a/src/engineai_ros2/src/engineai_hardware_interface.cpp
+++ b/src/engineai_ros2/src/engineai_hardware_interface.cpp
@@ -1,0 +1,326 @@
+// Copyright 2026 Kei Okada
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "engineai_ros2/engineai_hardware_interface.hpp"
+#include "engineai_ros2/engineai_util.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "interface_protocol/msg/parallel_parser_type.hpp"
+
+#include <sstream>
+#include <vector>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace engineai_hardware_interface
+{
+hardware_interface::CallbackReturn EngineAI_SystemPositionOnlyHardware::on_init(
+  const hardware_interface::HardwareComponentInterfaceParams & params)
+{
+  if (
+    hardware_interface::SystemInterface::on_init(params) !=
+    hardware_interface::CallbackReturn::SUCCESS)
+  {
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+
+  // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
+  hw_start_sec_ = stod(info_.hardware_parameters["example_param_hw_start_duration_sec"]);
+  hw_stop_sec_ = stod(info_.hardware_parameters["example_param_hw_stop_duration_sec"]);
+  hw_slowdown_ = stod(info_.hardware_parameters["example_param_hw_slowdown"]);
+  RCLCPP_INFO(get_logger(), "Robot hardware_component update_rate is %dHz", info_.rw_rate);
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
+
+  for (const hardware_interface::ComponentInfo & joint : info_.joints)
+  {
+    // EngineAI_SystemPositionOnly has exactly one state and command interface on each joint
+    if (joint.command_interfaces.size() != 1)
+    {
+      RCLCPP_FATAL(
+        get_logger(), "Joint '%s' has %zu command interfaces found. 1 expected.",
+        joint.name.c_str(), joint.command_interfaces.size());
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    if (joint.command_interfaces[0].name != hardware_interface::HW_IF_POSITION)
+    {
+      RCLCPP_FATAL(
+        get_logger(), "Joint '%s' have %s command interfaces found. '%s' expected.",
+        joint.name.c_str(), joint.command_interfaces[0].name.c_str(),
+        hardware_interface::HW_IF_POSITION);
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    if (joint.state_interfaces.size() != 1)
+    {
+      RCLCPP_FATAL(
+        get_logger(), "Joint '%s' has %zu state interface. 1 expected.", joint.name.c_str(),
+        joint.state_interfaces.size());
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    if (joint.state_interfaces[0].name != hardware_interface::HW_IF_POSITION)
+    {
+      RCLCPP_FATAL(
+        get_logger(), "Joint '%s' have %s state interface. '%s' expected.", joint.name.c_str(),
+        joint.state_interfaces[0].name.c_str(), hardware_interface::HW_IF_POSITION);
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+  }
+
+  // create node
+  node_ = std::make_shared<rclcpp::Node>("engineai_hardware_interface");
+
+  // initialize joint_names
+  joint_names_.clear();
+  joint_names_.reserve(info_.joints.size());
+  for (const auto &j : info_.joints) {
+    joint_names_.push_back(j.name);
+  }
+
+  //
+  const size_t n = joint_names_.size();
+
+  // Initialize per-joint vectors with defaults
+  stiffness_per_joint_.assign(n, default_stiffness_);
+  damping_per_joint_.assign(n, default_damping_);
+
+  // Parse overrides
+  const auto stiff_map = parse_name_value_csv(
+    get_string_param(info_.hardware_parameters, "stiffness_by_joint", ""));
+  const auto damp_map  = parse_name_value_csv(
+    get_string_param(info_.hardware_parameters, "damping_by_joint", ""));
+
+  // Apply overrides by joint name
+  for (size_t i = 0; i < n; ++i) {
+    const auto& name = joint_names_[i];
+
+    auto itS = stiff_map.find(name);
+    if (itS != stiff_map.end()) stiffness_per_joint_[i] = itS->second;
+
+    auto itD = damp_map.find(name);
+    if (itD != damp_map.end()) damping_per_joint_[i] = itD->second;
+  }
+
+  RCLCPP_INFO(rclcpp::get_logger("EngineAI_SystemPositionOnlyHardware"),
+              "Loaded per-joint stiffness/damping (n=%zu). Defaults: k=%.2f d=%.2f",
+              n, default_stiffness_, default_damping_);
+
+  // publisher
+  imu_pub_ = node_->create_publisher<sensor_msgs::msg::Imu>("imu/data_raw", rclcpp::QoS(10));
+  
+  joint_pub_ = node_->create_publisher<interface_protocol::msg::JointCommand>
+    ("/hardware/joint_command", rclcpp::QoS(10));
+
+  // subscriber
+  joint_sub_ = node_->create_subscription<interface_protocol::msg::JointState>(
+    "/hardware/joint_state", 10,
+    [this](interface_protocol::msg::JointState::SharedPtr msg)
+    {
+      std::lock_guard<std::mutex> lk(mtx_);
+      const auto noj = std::min(joint_names_.size(), msg->position.size());
+      for(size_t i = 0; i < noj; ++i) {
+	latest_pos_[joint_names_[i]] = msg->position[i];
+	latest_vel_[joint_names_[i]] = msg->velocity[i];
+	latest_tor_[joint_names_[i]] = msg->torque[i];						      
+      }
+    });
+
+  imu_sub_ = node_->create_subscription<interface_protocol::msg::ImuInfo>(
+    "/hardware/imu_info", 10,
+    [this](interface_protocol::msg::ImuInfo::SharedPtr msg)
+    {
+      std::lock_guard<std::mutex> lk(mtx_);
+      latest_imu_.header.stamp = node_->now();
+      latest_imu_.header.frame_id = "LINK_BASE";
+      // orientation
+      latest_imu_.orientation.x = msg->quaternion.x;
+      latest_imu_.orientation.y = msg->quaternion.y;
+      latest_imu_.orientation.z = msg->quaternion.z;
+      latest_imu_.orientation.w = msg->quaternion.w;
+      // linear
+      latest_imu_.linear_acceleration.x = msg->linear_acceleration.x;
+      latest_imu_.linear_acceleration.y = msg->linear_acceleration.y;
+      latest_imu_.linear_acceleration.z = msg->linear_acceleration.z;
+      // angular
+      latest_imu_.angular_velocity.x = msg->angular_velocity.x;
+      latest_imu_.angular_velocity.y = msg->angular_velocity.y;
+      latest_imu_.angular_velocity.z = msg->angular_velocity.z;
+      // orientation covariance [rad^2]
+      latest_imu_.orientation_covariance[0] = 1e-3;
+      latest_imu_.orientation_covariance[4] = 1e-3;
+      latest_imu_.orientation_covariance[8] = 1e-3;
+      // angular velocity covariance [(rad/s)^2]
+      latest_imu_.angular_velocity_covariance[0] = 1e-3;
+      latest_imu_.angular_velocity_covariance[4] = 1e-3;
+      latest_imu_.angular_velocity_covariance[8] = 1e-3;
+      // linear acceleration covariance [(m/s^2)^2]
+      latest_imu_.linear_acceleration_covariance[0] = 1e-2;
+      latest_imu_.linear_acceleration_covariance[4] = 1e-2;
+      latest_imu_.linear_acceleration_covariance[8] = 1e-2;
+
+      RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 500, "publish latest imu: %7.3f %7.3f %7.3f", latest_imu_.linear_acceleration.x, latest_imu_.linear_acceleration.y, latest_imu_.linear_acceleration.z);
+      // publish
+      imu_pub_->publish(latest_imu_);
+    });
+
+  RCLCPP_INFO(node_->get_logger(), "EngineAI topic-bridge hardware initialized");  
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn EngineAI_SystemPositionOnlyHardware::on_configure(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
+  RCLCPP_INFO(get_logger(), "Configuring ...please wait...");
+
+  for (int i = 0; i < hw_start_sec_; i++)
+  {
+    rclcpp::sleep_for(std::chrono::seconds(1));
+    RCLCPP_INFO(get_logger(), "%.1f seconds left...", hw_start_sec_ - i);
+  }
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
+
+  // reset values always when configuring hardware
+  for (const auto & [name, descr] : joint_state_interfaces_)
+  {
+    set_state(name, 0.0);
+  }
+  for (const auto & [name, descr] : joint_command_interfaces_)
+  {
+    set_command(name, 0.0);
+  }
+  RCLCPP_INFO(get_logger(), "Successfully configured!");
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn EngineAI_SystemPositionOnlyHardware::on_activate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
+  RCLCPP_INFO(get_logger(), "Activating ...please wait...");
+
+  for (int i = 0; i < hw_start_sec_; i++)
+  {
+    rclcpp::sleep_for(std::chrono::seconds(1));
+    RCLCPP_INFO(get_logger(), "%.1f seconds left...", hw_start_sec_ - i);
+  }
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
+
+  // command and state should be equal when starting
+  for (const auto & [name, descr] : joint_state_interfaces_)
+  {
+    set_command(name, get_state(name));
+  }
+
+  RCLCPP_INFO(get_logger(), "Successfully activated!");
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn EngineAI_SystemPositionOnlyHardware::on_deactivate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
+  RCLCPP_INFO(get_logger(), "Deactivating ...please wait...");
+
+  for (int i = 0; i < hw_stop_sec_; i++)
+  {
+    rclcpp::sleep_for(std::chrono::seconds(1));
+    RCLCPP_INFO(get_logger(), "%.1f seconds left...", hw_stop_sec_ - i);
+  }
+
+  RCLCPP_INFO(get_logger(), "Successfully deactivated!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::return_type EngineAI_SystemPositionOnlyHardware::read(
+  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+{
+  rclcpp::spin_some(node_);
+
+  std::lock_guard<std::mutex> lk(mtx_);
+  for (const auto & joint : joint_names_) {
+    auto it = latest_pos_.find(joint);
+    if (it != latest_pos_.end()) {
+      set_state(joint + "/position", it->second);
+    }
+  }
+  
+  return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type EngineAI_SystemPositionOnlyHardware::write(
+  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+{
+  // Build header line
+  const auto header = make_joint_header_line(joint_names_);
+  // Build position line
+  const auto pos_line = make_joint_value_line(joint_names_,
+					      [this](const std::string& key) {
+						return get_command(key);
+					      },
+					      "/position");
+  // Print both lines with throttling
+  RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 500, "%s\n%s",
+		       header.c_str(), pos_line.c_str());
+
+  // publish joint_command_ros
+  interface_protocol::msg::JointCommand cmd;
+    
+  // header
+  cmd.header.stamp = get_clock()->now();
+  cmd.header.frame_id = "";  // 必要なら robot 名など
+
+  const size_t n = joint_command_interfaces_.size();
+
+  cmd.position.reserve(n);
+  cmd.velocity.assign(n, 0.0);
+  cmd.feed_forward_torque.assign(n, 0.0);
+  cmd.torque.assign(n, 0.0);
+  cmd.stiffness = stiffness_per_joint_;
+  cmd.damping = damping_per_joint_;
+  for (const auto & name : joint_names_)
+  {
+    cmd.position.push_back(get_command(name + "/position"));  // position command
+  }
+  cmd.parallel_parser_type = interface_protocol::msg::ParallelParserType::RL_PARSER;
+
+  joint_pub_->publish(cmd);;
+  
+  return hardware_interface::return_type::OK;
+}
+
+}  // namespace engineai_hardware_interface
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(
+  engineai_hardware_interface::EngineAI_SystemPositionOnlyHardware, hardware_interface::SystemInterface)

--- a/src/engineai_ros2/src/joint_command_mux_node.cpp
+++ b/src/engineai_ros2/src/joint_command_mux_node.cpp
@@ -1,0 +1,388 @@
+// Copyright 2026 Kei Okada
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A ROS 2 node that merges two JointCommand topics.
+//
+// Design goals:
+// - Publish at the same rate as the RL command topic (RL topic is the "clock").
+// - Respect RL commands as the base, optionally overriding upper-body joints from ROS.
+// - Allow switching upper-body source between "ros" and "rl" at runtime.
+// - Smooth transitions to avoid sudden command jumps.
+
+#include <algorithm>
+#include <cctype>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/qos.hpp>
+#include <std_srvs/srv/set_bool.hpp>
+
+#include "interface_protocol/msg/joint_command.hpp"
+
+namespace engineai_ros2
+{
+
+using JointCommand = interface_protocol::msg::JointCommand;
+using SetBool = std_srvs::srv::SetBool;
+
+class JointCommandMuxNode final : public rclcpp::Node
+{
+public:
+  JointCommandMuxNode()
+  : rclcpp::Node("joint_command_mux")
+  {
+    // ----------------
+    // Parameters
+    // ----------------
+    // Which source should provide upper-body joints.
+    // - "ros": override upper-body joints from topic_ros
+    // - "rl": do not override (RL is used for all joints)
+    this->declare_parameter<std::string>("upper_source", "ros");
+
+    // Duration (seconds) used to blend from the previous published output to the new mode.
+    this->declare_parameter<double>("transition_time", 0.3);
+
+    // For safety, blending only position is usually best. If set false, all fields are blended.
+    this->declare_parameter<bool>("blend_position_only", false);
+
+    // Joint names in the same order as JointCommand arrays.
+    // This avoids relying on URDF parsing order.
+    this->declare_parameter<std::vector<std::string>>("joint_names", std::vector<std::string>{});
+
+    // Keywords used to classify lower-body joints. If a joint name contains any keyword
+    // (case-insensitive), it is treated as lower-body and never overridden from ROS.
+    this->declare_parameter<std::vector<std::string>>(
+      "lower_body_keywords", std::vector<std::string>{"HIP", "KNEE", "ANKL"});
+
+    // Topics
+    this->declare_parameter<std::string>("topic_out", "/hardware/joint_command");
+    this->declare_parameter<std::string>("topic_ros", "/hardware/joint_command_ros");
+    this->declare_parameter<std::string>("topic_rl", "/hardware/joint_command_rl");
+
+    upper_source_ = this->get_parameter("upper_source").as_string();
+    transition_time_ = this->get_parameter("transition_time").as_double();
+    blend_position_only_ = this->get_parameter("blend_position_only").as_bool();
+    joint_names_ = this->get_parameter("joint_names").as_string_array();
+    lower_body_keywords_ = this->get_parameter("lower_body_keywords").as_string_array();
+
+    topic_out_ = this->get_parameter("topic_out").as_string();
+    topic_ros_ = this->get_parameter("topic_ros").as_string();
+    topic_rl_ = this->get_parameter("topic_rl").as_string();
+
+    build_upper_body_indices();
+
+    // ----------------
+    // QoS
+    // ----------------
+    // Use SensorDataQoS for subscriptions to avoid QoS incompatibilities.
+    const auto qos_sub = rclcpp::SensorDataQoS();
+    const auto qos_pub = rclcpp::QoS(rclcpp::KeepLast(10)).best_effort();
+
+    // ----------------
+    // Pub/Sub
+    // ----------------
+    publisher_ = this->create_publisher<JointCommand>(topic_out_, qos_pub);
+
+    sub_ros_ = this->create_subscription<JointCommand>(
+      topic_ros_, qos_sub,
+      std::bind(&JointCommandMuxNode::on_ros_command, this, std::placeholders::_1));
+
+    // RL is the clock: publish happens only from this callback.
+    sub_rl_ = this->create_subscription<JointCommand>(
+      topic_rl_, qos_sub,
+      std::bind(&JointCommandMuxNode::on_rl_command, this, std::placeholders::_1));
+
+    // ----------------
+    // Services
+    // ----------------
+    // data=true  -> upper_source="rl"
+    // data=false -> upper_source="ros"
+    srv_set_upper_rl_ = this->create_service<SetBool>(
+      "~/set_upper_rl",
+      std::bind(
+        &JointCommandMuxNode::on_set_upper_rl,
+        this,
+        std::placeholders::_1,
+        std::placeholders::_2));
+
+    // ----------------
+    // Runtime parameter update
+    // ----------------
+    param_cb_ = this->add_on_set_parameters_callback(
+      std::bind(&JointCommandMuxNode::on_parameters, this, std::placeholders::_1));
+
+    RCLCPP_INFO(
+      get_logger(),
+      "Started joint_command_mux (upper_source=%s, transition_time=%.3f, blend_position_only=%s).",
+      upper_source_.c_str(),
+      transition_time_,
+      blend_position_only_ ? "true" : "false");
+  }
+
+private:
+  // dst = (1-alpha) * dst + alpha * src
+  template <typename VecT>
+  static void copy_or_blend(VecT & dst, const VecT & src, size_t idx, double alpha)
+  {
+    if (dst.size() <= idx || src.size() <= idx) {
+      return;
+    }
+    if (alpha <= 0.0) {
+      dst[idx] = src[idx];
+      return;
+    }
+    dst[idx] = (1.0 - alpha) * dst[idx] + alpha * src[idx];
+  }
+
+  static std::string to_upper(std::string s)
+  {
+    for (auto & c : s) {
+      c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+    }
+    return s;
+  }
+
+  bool is_lower_body_joint(const std::string & joint_name) const
+  {
+    const auto upper = to_upper(joint_name);
+    for (const auto & k : lower_body_keywords_) {
+      if (!k.empty() && upper.find(to_upper(k)) != std::string::npos) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void build_upper_body_indices()
+  {
+    upper_body_indices_.clear();
+
+    if (joint_names_.empty()) {
+      RCLCPP_WARN(
+        get_logger(),
+        "Parameter 'joint_names' is empty. No joints will be overridden from ROS.");
+      return;
+    }
+
+    for (size_t i = 0; i < joint_names_.size(); ++i) {
+      if (!is_lower_body_joint(joint_names_[i])) {
+        upper_body_indices_.push_back(i);
+      }
+    }
+
+    RCLCPP_INFO(
+      get_logger(),
+      "Loaded %zu joints. Upper-body indices=%zu.",
+      joint_names_.size(),
+      upper_body_indices_.size());
+  }
+
+  // Blend factor: 0 -> 1
+  double compute_alpha() const
+  {
+    if (!transition_active_ || transition_time_ <= 0.0) {
+      return 1.0;
+    }
+    const double dt = (this->now() - transition_start_).seconds();
+    return std::clamp(dt / transition_time_, 0.0, 1.0);
+  }
+
+  void start_transition_from_last_publish()
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    transition_from_ = last_published_;
+    if (transition_from_ && transition_time_ > 0.0) {
+      transition_active_ = true;
+      transition_start_ = this->now();
+    } else {
+      transition_active_ = false;
+    }
+  }
+
+  void set_upper_source(const std::string & source)
+  {
+    if (source != "ros" && source != "rl") {
+      RCLCPP_WARN(get_logger(), "Invalid upper_source='%s'.", source.c_str());
+      return;
+    }
+    if (upper_source_ == source) {
+      return;
+    }
+    start_transition_from_last_publish();
+    upper_source_ = source;
+    RCLCPP_INFO(get_logger(), "upper_source switched to '%s'.", upper_source_.c_str());
+  }
+
+  // ---------- callbacks ----------
+  void on_ros_command(const JointCommand::SharedPtr msg)
+  {
+    bool was_null = false;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      was_null = !latest_ros_;
+      latest_ros_ = msg;
+    }
+
+    // If we are already in ROS-upper mode and this is the first ROS message, blend into it.
+    if (upper_source_ == "ros" && was_null) {
+      start_transition_from_last_publish();
+    }
+  }
+
+  void on_rl_command(const JointCommand::SharedPtr rl_msg)
+  {
+    // 1) Build target output from RL.
+    auto out_msg = std::make_unique<JointCommand>(*rl_msg);
+    out_msg->header.stamp = this->now();
+
+    JointCommand::SharedPtr ros_msg;
+    std::shared_ptr<JointCommand> from_msg;
+    bool do_transition = false;
+
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      ros_msg = latest_ros_;
+      from_msg = transition_from_;
+      do_transition = transition_active_ && static_cast<bool>(from_msg);
+    }
+
+    // 2) Apply upper-body override from ROS if enabled.
+    if (upper_source_ == "ros" && ros_msg) {
+      for (const size_t idx : upper_body_indices_) {
+	RCLCPP_INFO(get_logger(), "idx %ld ros:%7.3f rl:%7.3f", idx, ros_msg->position[idx], out_msg->position[idx]);
+        copy_or_blend(out_msg->position, ros_msg->position, idx, 0.0);
+        if (!blend_position_only_) {
+          copy_or_blend(out_msg->velocity, ros_msg->velocity, idx, 0.0);
+          copy_or_blend(out_msg->feed_forward_torque, ros_msg->feed_forward_torque, idx, 0.0);
+          copy_or_blend(out_msg->torque, ros_msg->torque, idx, 0.0);
+          copy_or_blend(out_msg->stiffness, ros_msg->stiffness, idx, 0.0);
+          copy_or_blend(out_msg->damping, ros_msg->damping, idx, 0.0);
+        }
+      }
+    }
+
+    // 3) Blend from previous published output to the new target (both directions).
+    if (do_transition) {
+      const double alpha = compute_alpha();
+      const double alpha2 = 1.0 - alpha;  // Pull target towards "from" by (1-alpha).
+
+      for (const size_t idx : upper_body_indices_) {
+        // Desired: out = (1-alpha)*from + alpha*target
+        // copy_or_blend does: target = (1-a)*target + a*from
+        // so we use a = (1-alpha).
+        copy_or_blend(out_msg->position, from_msg->position, idx, alpha2);
+        if (!blend_position_only_) {
+          copy_or_blend(out_msg->velocity, from_msg->velocity, idx, alpha2);
+          copy_or_blend(out_msg->feed_forward_torque, from_msg->feed_forward_torque, idx, alpha2);
+          copy_or_blend(out_msg->torque, from_msg->torque, idx, alpha2);
+          copy_or_blend(out_msg->stiffness, from_msg->stiffness, idx, alpha2);
+          copy_or_blend(out_msg->damping, from_msg->damping, idx, alpha2);
+        }
+      }
+
+      if (alpha >= 1.0) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        transition_active_ = false;
+        transition_from_.reset();
+      }
+    }
+
+    // 4) Publish and store last published command.
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      last_published_ = std::make_shared<JointCommand>(*out_msg);
+    }
+    publisher_->publish(std::move(out_msg));
+  }
+
+  void on_set_upper_rl(
+    const std::shared_ptr<SetBool::Request> req,
+    std::shared_ptr<SetBool::Response> res)
+  {
+    set_upper_source(req->data ? "rl" : "ros");
+    res->success = true;
+    res->message = std::string("upper_source set to ") + (req->data ? "rl" : "ros");
+  }
+
+  rcl_interfaces::msg::SetParametersResult
+  on_parameters(const std::vector<rclcpp::Parameter> & params)
+  {
+    for (const auto & p : params) {
+      if (p.get_name() == "upper_source") {
+        set_upper_source(p.as_string());
+      } else if (p.get_name() == "transition_time") {
+        transition_time_ = p.as_double();
+      } else if (p.get_name() == "blend_position_only") {
+        blend_position_only_ = p.as_bool();
+      } else if (p.get_name() == "joint_names") {
+        joint_names_ = p.as_string_array();
+        build_upper_body_indices();
+      } else if (p.get_name() == "lower_body_keywords") {
+        lower_body_keywords_ = p.as_string_array();
+        build_upper_body_indices();
+      }
+    }
+
+    rcl_interfaces::msg::SetParametersResult result;
+    result.successful = true;
+    return result;
+  }
+
+private:
+  // Parameters
+  std::string upper_source_{"ros"};
+  double transition_time_{0.3};
+  bool blend_position_only_{true};
+  std::vector<std::string> joint_names_;
+  std::vector<std::string> lower_body_keywords_;
+
+  // Topics
+  std::string topic_out_;
+  std::string topic_ros_;
+  std::string topic_rl_;
+
+  // Joint mask
+  std::vector<size_t> upper_body_indices_;
+
+  // State (guarded)
+  std::mutex mutex_;
+  JointCommand::SharedPtr latest_ros_;
+  std::shared_ptr<JointCommand> last_published_;
+  std::shared_ptr<JointCommand> transition_from_;
+
+  // Transition
+  bool transition_active_{false};
+  rclcpp::Time transition_start_{0, 0, RCL_ROS_TIME};
+
+  // ROS entities
+  rclcpp::Publisher<JointCommand>::SharedPtr publisher_;
+  rclcpp::Subscription<JointCommand>::SharedPtr sub_ros_;
+  rclcpp::Subscription<JointCommand>::SharedPtr sub_rl_;
+  rclcpp::Service<SetBool>::SharedPtr srv_set_upper_rl_;
+  OnSetParametersCallbackHandle::SharedPtr param_cb_;
+};
+
+}  // namespace engineai_ros2
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<engineai_ros2::JointCommandMuxNode>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/engineai_ros2/src/joint_command_mux_node.cpp
+++ b/src/engineai_ros2/src/joint_command_mux_node.cpp
@@ -264,7 +264,6 @@ private:
     // 2) Apply upper-body override from ROS if enabled.
     if (upper_source_ == "ros" && ros_msg) {
       for (const size_t idx : upper_body_indices_) {
-	RCLCPP_INFO(get_logger(), "idx %ld ros:%7.3f rl:%7.3f", idx, ros_msg->position[idx], out_msg->position[idx]);
         copy_or_blend(out_msg->position, ros_msg->position, idx, 0.0);
         if (!blend_position_only_) {
           copy_or_blend(out_msg->velocity, ros_msg->velocity, idx, 0.0);

--- a/src/engineai_ros2/urdf/pm_v2.urdf.xacro
+++ b/src/engineai_ros2/urdf/pm_v2.urdf.xacro
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!-- Revolute-Revolute Manipulator -->
+<!--
+Copied and modified from ROS1 example -
+https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_description/urdf/rrbot.xacro
+-->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="pm_v2">
+  <xacro:arg name="prefix" default="" />
+
+  <!-- Import pm_v2 macro -->
+  <xacro:include filename="$(find engineai_ros2)/resource/robot/pm_v2/urdf/serial_pm_v2.urdf" />
+
+  <!-- Import pm_v2 ros2_control description -->
+  <xacro:include filename="$(find engineai_ros2)/urdf/pm_v2_ros2_control.xacro" />
+
+  <!-- Used for fixing robot -->
+  <!-- <link name="world"/> -->
+  <!-- <joint name="world_base_joint" type="fixed"> -->
+  <!--   <origin xyz="0 0 0" rpy="0 0 0" /> -->
+  <!--   <parent link="world"/> -->
+  <!--   <child link="LINK_BASE" /> -->
+  <!-- </joint> -->
+
+  <xacro:pm_v2_ros2_control
+    name="pm_v2" prefix="$(arg prefix)" />
+
+</robot>

--- a/src/engineai_ros2/urdf/pm_v2_ros2_control.xacro
+++ b/src/engineai_ros2/urdf/pm_v2_ros2_control.xacro
@@ -1,0 +1,146 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:macro name="pm_v2_ros2_control" params="name prefix">
+
+    <ros2_control name="${name}" type="system">
+      <hardware>
+        <plugin>engineai_hardware_interface/EngineAI_SystemPositionOnlyHardware</plugin>
+        <param name="example_param_hw_start_duration_sec">0</param>
+        <param name="example_param_hw_stop_duration_sec">3.0</param>
+        <param name="example_param_hw_slowdown">100</param>
+
+	<!-- Defaults -->
+	<param name="default_stiffness">20.0</param>
+	<param name="default_damping">1.0</param>
+	<!-- Per-joint overrides: "JOINT_NAME=value,JOINT_NAME=value,..." -->
+	<param name="stiffness_by_joint">
+	  J12_WAIST_YAW=200,J13_SHOULDER_PITCH_L=250,J14_SHOULDER_ROLL_L=250,J15_SHOULDER_YAW_L=250,J16_ELBOW_PITCH_L=250,J17_ELBOW_YAW_L=250,J18_SHOULDER_PITCH_R=250,J19_SHOULDER_ROLL_R=250,J20_SHOULDER_YAW_R=250,J21_ELBOW_PITCH_R=250,J22_ELBOW_YAW_R=250,J23_HEAD_YAW=100
+	</param>
+      </hardware>
+
+      <joint name="J00_HIP_PITCH_L">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J01_HIP_ROLL_L">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J02_HIP_YAW_L">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J03_KNEE_PITCH_L">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J04_ANKLE_PITCH_L">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J05_ANKLE_ROLL_L">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J06_HIP_PITCH_R">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J07_HIP_ROLL_R">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J08_HIP_YAW_R">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint  name="J09_KNEE_PITCH_R">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J10_ANKLE_PITCH_R">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J11_ANKLE_ROLL_R">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J12_WAIST_YAW">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J13_SHOULDER_PITCH_L">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J14_SHOULDER_ROLL_L">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J15_SHOULDER_YAW_L">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J16_ELBOW_PITCH_L">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J17_ELBOW_YAW_L">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J18_SHOULDER_PITCH_R">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J19_SHOULDER_ROLL_R">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J20_SHOULDER_YAW_R">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J21_ELBOW_PITCH_R">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J22_ELBOW_YAW_R">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+      <joint name="J23_HEAD_YAW">
+	<command_interface name="position"/>
+	<state_interface name="position"/>
+	<!-- <state_interface name="velocity"/> -->
+      </joint>
+    </ros2_control>
+
+  </xacro:macro>
+
+</robot>

--- a/src/engineai_ros2/urdf/pm_v2_ros2_control.xacro
+++ b/src/engineai_ros2/urdf/pm_v2_ros2_control.xacro
@@ -61,50 +61,62 @@
       <!-- Upper body joints (command + state) -->
       <joint name="J12_WAIST_YAW">
 	<command_interface name="position"/>
+	<command_interface name="velocity"/>
 	<state_interface name="position"/>
       </joint>
       <joint name="J13_SHOULDER_PITCH_L">
 	<command_interface name="position"/>
+	<command_interface name="velocity"/>
 	<state_interface name="position"/>
       </joint>
       <joint name="J14_SHOULDER_ROLL_L">
 	<command_interface name="position"/>
+	<command_interface name="velocity"/>
 	<state_interface name="position"/>
       </joint>
       <joint name="J15_SHOULDER_YAW_L">
 	<command_interface name="position"/>
+	<command_interface name="velocity"/>
 	<state_interface name="position"/>
       </joint>
       <joint name="J16_ELBOW_PITCH_L">
 	<command_interface name="position"/>
+	<command_interface name="velocity"/>
 	<state_interface name="position"/>
       </joint>
       <joint name="J17_ELBOW_YAW_L">
 	<command_interface name="position"/>
+	<command_interface name="velocity"/>
 	<state_interface name="position"/>
       </joint>
       <joint name="J18_SHOULDER_PITCH_R">
 	<command_interface name="position"/>
+	<command_interface name="velocity"/>
 	<state_interface name="position"/>
       </joint>
       <joint name="J19_SHOULDER_ROLL_R">
 	<command_interface name="position"/>
+	<command_interface name="velocity"/>
 	<state_interface name="position"/>
       </joint>
       <joint name="J20_SHOULDER_YAW_R">
 	<command_interface name="position"/>
+	<command_interface name="velocity"/>
 	<state_interface name="position"/>
       </joint>
       <joint name="J21_ELBOW_PITCH_R">
 	<command_interface name="position"/>
+	<command_interface name="velocity"/>
 	<state_interface name="position"/>
       </joint>
       <joint name="J22_ELBOW_YAW_R">
 	<command_interface name="position"/>
+	<command_interface name="velocity"/>
 	<state_interface name="position"/>
       </joint>
       <joint name="J23_HEAD_YAW">
 	<command_interface name="position"/>
+	<command_interface name="velocity"/>
 	<state_interface name="position"/>
       </joint>
     </ros2_control>

--- a/src/engineai_ros2/urdf/pm_v2_ros2_control.xacro
+++ b/src/engineai_ros2/urdf/pm_v2_ros2_control.xacro
@@ -10,134 +10,102 @@
         <param name="example_param_hw_stop_duration_sec">3.0</param>
         <param name="example_param_hw_slowdown">100</param>
 
-	<!-- Defaults -->
-	<param name="default_stiffness">20.0</param>
-	<param name="default_damping">1.0</param>
-	<!-- Per-joint overrides: "JOINT_NAME=value,JOINT_NAME=value,..." -->
-	<param name="stiffness_by_joint">
-	  J12_WAIST_YAW=200,J13_SHOULDER_PITCH_L=250,J14_SHOULDER_ROLL_L=250,J15_SHOULDER_YAW_L=250,J16_ELBOW_PITCH_L=250,J17_ELBOW_YAW_L=250,J18_SHOULDER_PITCH_R=250,J19_SHOULDER_ROLL_R=250,J20_SHOULDER_YAW_R=250,J21_ELBOW_PITCH_R=250,J22_ELBOW_YAW_R=250,J23_HEAD_YAW=100
-	</param>
+	<!-- stiffness=80: high enough to move joints via incremental JTC commands,
+	     low enough to avoid aggressive snapping from rqt goal preemption.
+	     (examples use 20.0 because they send large single-step targets;
+	      JTC sends fine increments so a higher value is needed.) -->
+	<param name="default_stiffness">80.0</param>
+	<param name="default_damping">2.0</param>
       </hardware>
 
+      <!-- Left leg joints (state-only — controlled by onboard RL locomotion controller) -->
       <joint name="J00_HIP_PITCH_L">
-	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J01_HIP_ROLL_L">
-	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J02_HIP_YAW_L">
-	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J03_KNEE_PITCH_L">
-	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J04_ANKLE_PITCH_L">
-	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J05_ANKLE_ROLL_L">
-	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
+
+      <!-- Right leg joints (state-only — controlled by onboard RL locomotion controller) -->
       <joint name="J06_HIP_PITCH_R">
-	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J07_HIP_ROLL_R">
-	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J08_HIP_YAW_R">
-	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
-      <joint  name="J09_KNEE_PITCH_R">
-	<command_interface name="position"/>
+      <joint name="J09_KNEE_PITCH_R">
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J10_ANKLE_PITCH_R">
-	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J11_ANKLE_ROLL_R">
-	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
+
+      <!-- Upper body joints (command + state) -->
       <joint name="J12_WAIST_YAW">
 	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J13_SHOULDER_PITCH_L">
 	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J14_SHOULDER_ROLL_L">
 	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J15_SHOULDER_YAW_L">
 	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J16_ELBOW_PITCH_L">
 	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J17_ELBOW_YAW_L">
 	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J18_SHOULDER_PITCH_R">
 	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J19_SHOULDER_ROLL_R">
 	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J20_SHOULDER_YAW_R">
 	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J21_ELBOW_PITCH_R">
 	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J22_ELBOW_YAW_R">
 	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
       <joint name="J23_HEAD_YAW">
 	<command_interface name="position"/>
 	<state_interface name="position"/>
-	<!-- <state_interface name="velocity"/> -->
       </joint>
     </ros2_control>
 

--- a/src/interface_example/launch/rl_basic_example.launch.py
+++ b/src/interface_example/launch/rl_basic_example.launch.py
@@ -1,10 +1,20 @@
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 import os
 
 
 def generate_launch_description():
+    # get command line arguments
+    command_topic_arg = DeclareLaunchArgument(
+        'joint_command_topic',
+        default_value='/hardware/joint_command',
+        description='Target topic name for remapping /hardware/joint_command'
+    )
+    target_topic = LaunchConfiguration('joint_command_topic')
+
     # Get package path using get_package_share_directory
     package_dir = get_package_share_directory('interface_example')
 
@@ -30,10 +40,12 @@ def generate_launch_description():
         executable='rl_basic_example',
         name='rl_basic_example',
         arguments=[config_dir],
+        remappings=[('/hardware/joint_command', target_topic)],
         output='screen',
         emulate_tty=True,
     )
 
     return LaunchDescription([
+        command_topic_arg,
         hardware_node
     ])


### PR DESCRIPTION
Repecting #7, I added the upperbody ROS2 controller for PM01.

- **Add launch argument for joint_command_topic and enable dynamic remapping**
- **ROS 2 integration utilities for the EngineAI robot family (PM‑V2 today, designed to be extended to other platforms such as T800).**
- **change for upper body controller**
- **enable open_loop_control to use the EngineAI original controller**
